### PR TITLE
SMOODEV-606: Add bare ./browser export

### DIFF
--- a/.changeset/browser-bare-export.md
+++ b/.changeset/browser-bare-export.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+Add explicit `./browser` subpath export so `import fetch from '@smooai/fetch/browser'` resolves without the trailing `/index`. The existing `./browser/*` wildcard doesn't match the bare `./browser` specifier per the Node.js exports spec — the `*` requires at least one character — so consumers previously had to write `@smooai/fetch/browser/index`, which contradicts the documented API. Adds a dedicated entry pointing at `dist/browser/index.{mjs,js,d.ts}`. The wildcard form continues to work for any future browser-side subpaths.

--- a/.smooai-logs/output.ansi
+++ b/.smooai-logs/output.ansi
@@ -953,3 +953,170 @@
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://smoo.ai\" retries failed after 2 retries[39m[22m",
+  "time": "[34m2026-04-19T01:23:03.906Z[39m",
+  "error": "{}; HTTP Error Response: 501 undefined",
+  "errorDetails": [
+    {
+      "message": "{}; HTTP Error Response: 501 undefined",
+      "name": "Error",
+      "response": {
+        "data": {
+        },
+        "dataString": "{}",
+        "headers": {
+        },
+        "isJson": true,
+        "ok": false,
+        "status": 501
+      },
+      "stack": "Error: {}; HTTP Error Response: 501 undefined\n    at doGlobalFetch (/Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/src/fetch.ts:295:11)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:459:9)\n    at doFetch (/Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/src/fetch.ts:330:16)\n    at /Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/src/fetch.spec.ts:99:7\n    at file:///Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:20"
+    }
+  ],
+  "@message": "HTTP request \"GET https://smoo.ai\" retries failed after 2 retries",
+  "@timestamp": "2026-04-19T01:23:03.906Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "doFetch (/Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/src/fetch.ts:365:16)",
+      "runNextTicks (node:internal/process/task_queues:65:5)"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "6643a8a8-3884-4a69-bd15-d6512dfc2759"
+        },
+        "hostname": "smoo.ai",
+        "method": "GET",
+        "path": "/",
+        "queryString": ""
+      },
+      "response": {
+        "body": "{}",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "statusCode": 501
+      }
+    }
+  },
+  "correlationId": "6230525d-4363-4973-8bc5-87ac525940e9",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "6230525d-4363-4973-8bc5-87ac525940e9",
+  "traceId": "6230525d-4363-4973-8bc5-87ac525940e9"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://smoo.ai\" timed out (Error) after 10000 ms[39m[22m",
+  "time": "[34m2026-04-19T01:23:34.315Z[39m",
+  "error": "{}; HTTP Error Response: 501 undefined; Timed out",
+  "errorDetails": [
+    {
+      "message": "Timed out",
+      "name": "Error",
+      "stack": "Error: Timed out\n    at file:///Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/node_modules/.pnpm/mollitia@0.1.1/node_modules/mollitia/dist/index.js:258:34\n    at callTimer (file:///Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2249:25)\n    at doTickInner (file:///Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2852:30)\n    at doTick (file:///Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2933:21)\n    at Immediate.<anonymous> (file:///Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2953:30)\n    at processImmediate (node:internal/timers:491:21)"
+    }
+  ],
+  "@message": "HTTP request \"GET https://smoo.ai\" timed out (Error) after 10000 ms",
+  "@timestamp": "2026-04-19T01:23:34.315Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "doFetch (/Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/src/fetch.ts:351:14)",
+      "/Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/src/fetch.spec.ts:170:7"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "6643a8a8-3884-4a69-bd15-d6512dfc2759"
+        },
+        "hostname": "smoo.ai",
+        "method": "GET",
+        "path": "/",
+        "queryString": ""
+      }
+    }
+  },
+  "correlationId": "6230525d-4363-4973-8bc5-87ac525940e9",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "6230525d-4363-4973-8bc5-87ac525940e9",
+  "traceId": "6230525d-4363-4973-8bc5-87ac525940e9"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://example.com/api/timeout\" timed out (Error) after 300 ms[39m[22m",
+  "time": "[34m2026-04-19T01:23:06.935Z[39m",
+  "error": "Timed out",
+  "errorDetails": [
+    {
+      "message": "Timed out",
+      "name": "Error",
+      "stack": "Error: Timed out\n    at Timeout.<anonymous> (file:///Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/node_modules/.pnpm/mollitia@0.1.1/node_modules/mollitia/dist/index.js:258:34)\n    at listOnTimeout (node:internal/timers:594:17)\n    at processTimers (node:internal/timers:529:7)"
+    }
+  ],
+  "@message": "HTTP request \"GET https://example.com/api/timeout\" timed out (Error) after 300 ms",
+  "@timestamp": "2026-04-19T01:23:06.935Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "V.doFetch [as func] (/Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/src/fetch.ts:351:14)",
+      "/Users/brentrager/dev/smooai/fetch-SMOODEV-605-browser-export/src/fetch.integration.spec.ts:135:7"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "d72f9a08-af9a-48e6-adb3-3ffcaf4a20d8"
+        },
+        "hostname": "example.com",
+        "method": "GET",
+        "path": "/api/timeout",
+        "queryString": ""
+      }
+    }
+  },
+  "correlationId": "e1278454-7aed-4ee7-a3d0-11e019cecdbe",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "e1278454-7aed-4ee7-a3d0-11e019cecdbe",
+  "traceId": "e1278454-7aed-4ee7-a3d0-11e019cecdbe"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,6 +26,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Branch naming
 
 Always prefix with the Jira ticket number:
+
 ```
 SMOODEV-XX-short-description
 ```
@@ -33,6 +34,7 @@ SMOODEV-XX-short-description
 ### Commit messages
 
 Always prefix with the Jira ticket:
+
 ```
 SMOODEV-XX: Descriptive message explaining why
 ```

--- a/go/fetch/README.md
+++ b/go/fetch/README.md
@@ -61,12 +61,12 @@ Ever had a Go microservice pile up goroutines because a downstream API was down?
 go get github.com/SmooAI/fetch/go/fetch
 ```
 
-| Language   | Package | Install |
-| ---------- | ------- | ------- |
-| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch` |
-| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/) | `pip install smooai-fetch` |
-| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch) | `cargo add smooai-fetch` |
-| Go         | `github.com/SmooAI/fetch/go/fetch` | `go get github.com/SmooAI/fetch/go/fetch` |
+| Language   | Package                                                        | Install                                   |
+| ---------- | -------------------------------------------------------------- | ----------------------------------------- |
+| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                  |
+| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                |
+| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                  |
+| Go         | `github.com/SmooAI/fetch/go/fetch`                             | `go get github.com/SmooAI/fetch/go/fetch` |
 
 ## The Power of Resilient Fetching
 
@@ -332,32 +332,32 @@ Out of the box, smooai-fetch is configured for the real world:
 
 ### Top-Level Generic Functions
 
-| Function | Description |
-| -------- | ----------- |
-| `Fetch[T](ctx, client, method, url, body, opts)` | Generic request with any method |
-| `Get[T](ctx, client, url, opts)` | GET request |
-| `Post[T](ctx, client, url, body, opts)` | POST request |
-| `Put[T](ctx, client, url, body, opts)` | PUT request |
-| `Patch[T](ctx, client, url, body, opts)` | PATCH request |
-| `Delete[T](ctx, client, url, opts)` | DELETE request |
-| `SimpleGet(ctx, client, url, opts)` | GET with untyped `any` response |
-| `SimplePost(ctx, client, url, body, opts)` | POST with untyped `any` response |
+| Function                                         | Description                      |
+| ------------------------------------------------ | -------------------------------- |
+| `Fetch[T](ctx, client, method, url, body, opts)` | Generic request with any method  |
+| `Get[T](ctx, client, url, opts)`                 | GET request                      |
+| `Post[T](ctx, client, url, body, opts)`          | POST request                     |
+| `Put[T](ctx, client, url, body, opts)`           | PUT request                      |
+| `Patch[T](ctx, client, url, body, opts)`         | PATCH request                    |
+| `Delete[T](ctx, client, url, opts)`              | DELETE request                   |
+| `SimpleGet(ctx, client, url, opts)`              | GET with untyped `any` response  |
+| `SimplePost(ctx, client, url, body, opts)`       | POST with untyped `any` response |
 
 ### `ClientBuilder` Methods
 
-| Method | Description |
-| ------ | ----------- |
-| `NewClientBuilder()` | Create builder with default retry + timeout |
-| `.WithHTTPClient(c)` | Use a custom `*http.Client` |
-| `.WithBaseHeaders(headers)` | Set headers included in every request |
-| `.WithTimeout(duration)` | Set request timeout |
-| `.WithNoTimeout()` | Disable timeout |
-| `.WithRetry(opts)` | Configure retry behavior |
-| `.WithNoRetry()` | Disable retries |
-| `.WithRateLimit(maxRequests, period)` | Configure sliding-window rate limiter |
-| `.WithCircuitBreaker(name, opts)` | Configure circuit breaker |
-| `.WithHooks(hooks)` | Set lifecycle hooks |
-| `.Build()` | Build the `*Client` |
+| Method                                | Description                                 |
+| ------------------------------------- | ------------------------------------------- |
+| `NewClientBuilder()`                  | Create builder with default retry + timeout |
+| `.WithHTTPClient(c)`                  | Use a custom `*http.Client`                 |
+| `.WithBaseHeaders(headers)`           | Set headers included in every request       |
+| `.WithTimeout(duration)`              | Set request timeout                         |
+| `.WithNoTimeout()`                    | Disable timeout                             |
+| `.WithRetry(opts)`                    | Configure retry behavior                    |
+| `.WithNoRetry()`                      | Disable retries                             |
+| `.WithRateLimit(maxRequests, period)` | Configure sliding-window rate limiter       |
+| `.WithCircuitBreaker(name, opts)`     | Configure circuit breaker                   |
+| `.WithHooks(hooks)`                   | Set lifecycle hooks                         |
+| `.Build()`                            | Build the `*Client`                         |
 
 ### Error Handling
 

--- a/package.json
+++ b/package.json
@@ -29,15 +29,21 @@
             "require": "./dist/index.js",
             "default": "./dist/index.js"
         },
-        "./*": {
-            "types": "./dist/*.d.ts",
-            "import": "./dist/*.mjs",
-            "require": "./dist/*.js"
+        "./browser": {
+            "types": "./dist/browser/index.d.ts",
+            "import": "./dist/browser/index.mjs",
+            "require": "./dist/browser/index.js",
+            "default": "./dist/browser/index.js"
         },
         "./browser/*": {
             "types": "./dist/browser/*.d.ts",
             "import": "./dist/browser/*.mjs",
             "require": "./dist/browser/*.js"
+        },
+        "./*": {
+            "types": "./dist/*.d.ts",
+            "import": "./dist/*.mjs",
+            "require": "./dist/*.js"
         }
     },
     "publishConfig": {
@@ -98,6 +104,7 @@
         "oxfmt": "^0.28.0",
         "oxlint": "^0.16.0",
         "tsup": "^8.4.0",
+        "typescript": "^5.8.2",
         "vite": "^6.2.4",
         "vite-node": "^3.1.1",
         "vite-tsconfig-paths": "^5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,6 +61,9 @@ importers:
       tsup:
         specifier: ^8.4.0
         version: 8.4.0(postcss@8.5.3)(typescript@5.8.2)(yaml@2.7.0)
+      typescript:
+        specifier: ^5.8.2
+        version: 5.8.2
       vite:
         specifier: ^6.2.4
         version: 6.2.4(@types/node@22.13.10)(yaml@2.7.0)

--- a/python/README.md
+++ b/python/README.md
@@ -71,12 +71,12 @@ or with [uv](https://docs.astral.sh/uv/):
 uv add smooai-fetch
 ```
 
-| Language   | Package | Install |
-| ---------- | ------- | ------- |
-| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch` |
-| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/) | `pip install smooai-fetch` |
-| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch) | `cargo add smooai-fetch` |
-| Go         | `github.com/SmooAI/fetch/go/fetch` | `go get github.com/SmooAI/fetch/go/fetch` |
+| Language   | Package                                                        | Install                                   |
+| ---------- | -------------------------------------------------------------- | ----------------------------------------- |
+| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                  |
+| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                |
+| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                  |
+| Go         | `github.com/SmooAI/fetch/go/fetch`                             | `go get github.com/SmooAI/fetch/go/fetch` |
 
 ## The Power of Resilient Fetching
 

--- a/rust/fetch/README.md
+++ b/rust/fetch/README.md
@@ -72,12 +72,12 @@ or via cargo:
 cargo add smooai-fetch
 ```
 
-| Language   | Package | Install |
-| ---------- | ------- | ------- |
-| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch` |
-| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/) | `pip install smooai-fetch` |
-| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch) | `cargo add smooai-fetch` |
-| Go         | `github.com/SmooAI/fetch/go/fetch` | `go get github.com/SmooAI/fetch/go/fetch` |
+| Language   | Package                                                        | Install                                   |
+| ---------- | -------------------------------------------------------------- | ----------------------------------------- |
+| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                  |
+| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                |
+| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                  |
+| Go         | `github.com/SmooAI/fetch/go/fetch`                             | `go get github.com/SmooAI/fetch/go/fetch` |
 
 ## The Power of Resilient Fetching
 
@@ -312,20 +312,20 @@ let response = fetch::<MyType>("https://api.example.com/data", init).await?;
 
 ### `FetchBuilder<T>` Methods
 
-| Method | Description |
-| ------ | ----------- |
-| `FetchBuilder::new()` | Create builder with default retry + timeout |
-| `.with_timeout(ms)` | Set timeout in milliseconds |
-| `.without_timeout()` | Disable timeout |
-| `.with_retry(options)` | Configure retry behavior |
-| `.without_retry()` | Disable retries |
-| `.with_rate_limit(limit, period_ms)` | Configure sliding-window rate limiter |
-| `.with_circuit_breaker(fail, success, delay_ms)` | Configure circuit breaker |
-| `.with_init(init)` | Set default headers/method for all requests |
-| `.with_pre_request_hook(hook)` | Hook called before each request |
-| `.with_post_response_success_hook(hook)` | Hook called on successful response |
-| `.with_post_response_error_hook(hook)` | Hook called on error response |
-| `.build()` | Build the `FetchClient<T>` |
+| Method                                           | Description                                 |
+| ------------------------------------------------ | ------------------------------------------- |
+| `FetchBuilder::new()`                            | Create builder with default retry + timeout |
+| `.with_timeout(ms)`                              | Set timeout in milliseconds                 |
+| `.without_timeout()`                             | Disable timeout                             |
+| `.with_retry(options)`                           | Configure retry behavior                    |
+| `.without_retry()`                               | Disable retries                             |
+| `.with_rate_limit(limit, period_ms)`             | Configure sliding-window rate limiter       |
+| `.with_circuit_breaker(fail, success, delay_ms)` | Configure circuit breaker                   |
+| `.with_init(init)`                               | Set default headers/method for all requests |
+| `.with_pre_request_hook(hook)`                   | Hook called before each request             |
+| `.with_post_response_success_hook(hook)`         | Hook called on successful response          |
+| `.with_post_response_error_hook(hook)`           | Hook called on error response               |
+| `.build()`                                       | Build the `FetchClient<T>`                  |
 
 ### Error Handling
 


### PR DESCRIPTION
## Summary

- Docs say `import fetch from '@smooai/fetch/browser'` but the exports map only declared `./browser/*` (wildcard), which doesn't match the bare `./browser` specifier — consumers hit `Rollup failed to resolve import "@smooai/fetch/browser"`.
- Add an explicit `./browser` entry pointing at `dist/browser/index`; keep the wildcard for future subpaths.
- Pin `typescript@^5.8.2` as a direct devDep so `pnpm typecheck` can find `tsc` without relying on pnpm's transitive bin hoisting.

## Test plan

- [x] Existing `dist/browser/index.{mjs,js,d.ts}` already produced by tsup — no build change
- [ ] After publish, verify `@smooai/fetch/browser` resolves in the monorepo's ui-form-widget vite build (currently using `/browser/index` as a workaround)

🤖 Generated with [Claude Code](https://claude.com/claude-code)