### PR TITLE
feat: add top-level browser export condition

### DIFF
--- a/.changeset/browser-export-condition.md
+++ b/.changeset/browser-export-condition.md
@@ -1,0 +1,17 @@
+---
+'@smooai/fetch': minor
+---
+
+**Add top-level `browser` export condition**
+
+`@smooai/fetch` already shipped a browser-safe build under `./browser`, but the top-level `.` entry had no `browser` condition in the exports map. Browser bundlers (Vite, webpack with `target: 'web'`, esbuild with `platform: 'browser'`) therefore resolved `import fetch from '@smooai/fetch'` to the Node entry, pulling `@smooai/logger` + `rotating-file-stream` + other Node-only dependencies into the browser bundle.
+
+Adding the `browser` condition on `.` means consumers can now do:
+
+```ts
+import fetch from '@smooai/fetch';
+```
+
+…and the bundler automatically picks the browser-safe dist when building for a browser target. No aliasing, no explicit `/browser` subpath import required.
+
+Consumers that were aliasing `@smooai/fetch` → `@smooai/fetch/browser/index` as a workaround (e.g. `@smooai/config`'s tsup build) can drop that alias on upgrade.

--- a/.smooai-logs/output.ansi
+++ b/.smooai-logs/output.ansi
@@ -1120,3 +1120,337 @@
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
 ----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://smoo.ai\" retries failed after 2 retries[39m[22m",
+  "time": "[34m2026-04-21T16:54:20.617Z[39m",
+  "error": "{}; HTTP Error Response: 501 undefined",
+  "errorDetails": [
+    {
+      "message": "{}; HTTP Error Response: 501 undefined",
+      "name": "Error",
+      "response": {
+        "data": {
+        },
+        "dataString": "{}",
+        "headers": {
+        },
+        "isJson": true,
+        "ok": false,
+        "status": 501
+      },
+      "stack": "Error: {}; HTTP Error Response: 501 undefined\n    at doGlobalFetch (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:295:11)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:459:9)\n    at doFetch (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:330:16)\n    at /Users/brentrager/dev/smooai/fetch/src/fetch.spec.ts:99:7\n    at file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:20"
+    }
+  ],
+  "@message": "HTTP request \"GET https://smoo.ai\" retries failed after 2 retries",
+  "@timestamp": "2026-04-21T16:54:20.617Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "doFetch (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:365:16)",
+      "runNextTicks (node:internal/process/task_queues:65:5)"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "6ecb3aff-63b5-424d-ba02-be8f85c4ea06"
+        },
+        "hostname": "smoo.ai",
+        "method": "GET",
+        "path": "/",
+        "queryString": ""
+      },
+      "response": {
+        "body": "{}",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "statusCode": 501
+      }
+    }
+  },
+  "correlationId": "a2a95608-39a3-4e3f-b1ae-b237a27c56e5",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "a2a95608-39a3-4e3f-b1ae-b237a27c56e5",
+  "traceId": "a2a95608-39a3-4e3f-b1ae-b237a27c56e5"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://smoo.ai\" timed out (Error) after 10000 ms[39m[22m",
+  "time": "[34m2026-04-21T16:54:50.420Z[39m",
+  "error": "{}; HTTP Error Response: 501 undefined; Timed out",
+  "errorDetails": [
+    {
+      "message": "Timed out",
+      "name": "Error",
+      "stack": "Error: Timed out\n    at file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/mollitia@0.1.1/node_modules/mollitia/dist/index.js:258:34\n    at callTimer (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2249:25)\n    at doTickInner (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2852:30)\n    at doTick (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2933:21)\n    at Immediate.<anonymous> (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2953:30)\n    at processImmediate (node:internal/timers:491:21)"
+    }
+  ],
+  "@message": "HTTP request \"GET https://smoo.ai\" timed out (Error) after 10000 ms",
+  "@timestamp": "2026-04-21T16:54:50.420Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "doFetch (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:351:14)",
+      "/Users/brentrager/dev/smooai/fetch/src/fetch.spec.ts:170:7"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "6ecb3aff-63b5-424d-ba02-be8f85c4ea06"
+        },
+        "hostname": "smoo.ai",
+        "method": "GET",
+        "path": "/",
+        "queryString": ""
+      }
+    }
+  },
+  "correlationId": "a2a95608-39a3-4e3f-b1ae-b237a27c56e5",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "a2a95608-39a3-4e3f-b1ae-b237a27c56e5",
+  "traceId": "a2a95608-39a3-4e3f-b1ae-b237a27c56e5"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://example.com/api/timeout\" timed out (Error) after 300 ms[39m[22m",
+  "time": "[34m2026-04-21T16:54:24.094Z[39m",
+  "error": "Timed out",
+  "errorDetails": [
+    {
+      "message": "Timed out",
+      "name": "Error",
+      "stack": "Error: Timed out\n    at Timeout.<anonymous> (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/mollitia@0.1.1/node_modules/mollitia/dist/index.js:258:34)\n    at listOnTimeout (node:internal/timers:594:17)\n    at processTimers (node:internal/timers:529:7)"
+    }
+  ],
+  "@message": "HTTP request \"GET https://example.com/api/timeout\" timed out (Error) after 300 ms",
+  "@timestamp": "2026-04-21T16:54:24.094Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "V.doFetch [as func] (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:351:14)",
+      "/Users/brentrager/dev/smooai/fetch/src/fetch.integration.spec.ts:135:7"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "218345d4-51f9-43cf-8f38-5856df1cfdc1"
+        },
+        "hostname": "example.com",
+        "method": "GET",
+        "path": "/api/timeout",
+        "queryString": ""
+      }
+    }
+  },
+  "correlationId": "26580b2d-3f57-458e-bc53-5e602c74d701",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "26580b2d-3f57-458e-bc53-5e602c74d701",
+  "traceId": "26580b2d-3f57-458e-bc53-5e602c74d701"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://smoo.ai\" retries failed after 2 retries[39m[22m",
+  "time": "[34m2026-04-21T16:55:02.056Z[39m",
+  "error": "{}; HTTP Error Response: 501 undefined",
+  "errorDetails": [
+    {
+      "message": "{}; HTTP Error Response: 501 undefined",
+      "name": "Error",
+      "response": {
+        "data": {
+        },
+        "dataString": "{}",
+        "headers": {
+        },
+        "isJson": true,
+        "ok": false,
+        "status": 501
+      },
+      "stack": "Error: {}; HTTP Error Response: 501 undefined\n    at doGlobalFetch (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:295:11)\n    at runNextTicks (node:internal/process/task_queues:65:5)\n    at processImmediate (node:internal/timers:459:9)\n    at doFetch (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:330:16)\n    at /Users/brentrager/dev/smooai/fetch/src/fetch.spec.ts:99:7\n    at file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/@vitest+runner@3.1.1/node_modules/@vitest/runner/dist/index.js:595:20"
+    }
+  ],
+  "@message": "HTTP request \"GET https://smoo.ai\" retries failed after 2 retries",
+  "@timestamp": "2026-04-21T16:55:02.056Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "doFetch (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:365:16)",
+      "runNextTicks (node:internal/process/task_queues:65:5)"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "a188a730-da56-4ef3-87a8-f9176ca18dc0"
+        },
+        "hostname": "smoo.ai",
+        "method": "GET",
+        "path": "/",
+        "queryString": ""
+      },
+      "response": {
+        "body": "{}",
+        "headers": {
+          "content-type": "application/json"
+        },
+        "statusCode": 501
+      }
+    }
+  },
+  "correlationId": "fffe3d77-9842-461c-aadc-b4466f5fcab4",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "fffe3d77-9842-461c-aadc-b4466f5fcab4",
+  "traceId": "fffe3d77-9842-461c-aadc-b4466f5fcab4"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://smoo.ai\" timed out (Error) after 10000 ms[39m[22m",
+  "time": "[34m2026-04-21T16:55:32.028Z[39m",
+  "error": "{}; HTTP Error Response: 501 undefined; Timed out",
+  "errorDetails": [
+    {
+      "message": "Timed out",
+      "name": "Error",
+      "stack": "Error: Timed out\n    at file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/mollitia@0.1.1/node_modules/mollitia/dist/index.js:258:34\n    at callTimer (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2249:25)\n    at doTickInner (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2852:30)\n    at doTick (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2933:21)\n    at Immediate.<anonymous> (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/vitest@3.1.1_@types+node@22.13.10_msw@2.7.3_@types+node@22.13.10_typescript@5.8.2__yaml@2.7.0/node_modules/vitest/dist/chunks/vi.B-PuvDzu.js:2953:30)\n    at processImmediate (node:internal/timers:491:21)"
+    }
+  ],
+  "@message": "HTTP request \"GET https://smoo.ai\" timed out (Error) after 10000 ms",
+  "@timestamp": "2026-04-21T16:55:32.028Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "doFetch (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:351:14)",
+      "/Users/brentrager/dev/smooai/fetch/src/fetch.spec.ts:170:7"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "a188a730-da56-4ef3-87a8-f9176ca18dc0"
+        },
+        "hostname": "smoo.ai",
+        "method": "GET",
+        "path": "/",
+        "queryString": ""
+      }
+    }
+  },
+  "correlationId": "fffe3d77-9842-461c-aadc-b4466f5fcab4",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "fffe3d77-9842-461c-aadc-b4466f5fcab4",
+  "traceId": "fffe3d77-9842-461c-aadc-b4466f5fcab4"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+{
+  "msg": "[1m[32mHTTP request \"GET https://example.com/api/timeout\" timed out (Error) after 300 ms[39m[22m",
+  "time": "[34m2026-04-21T16:55:05.128Z[39m",
+  "error": "Timed out",
+  "errorDetails": [
+    {
+      "message": "Timed out",
+      "name": "Error",
+      "stack": "Error: Timed out\n    at Timeout.<anonymous> (file:///Users/brentrager/dev/smooai/fetch/node_modules/.pnpm/mollitia@0.1.1/node_modules/mollitia/dist/index.js:258:34)\n    at listOnTimeout (node:internal/timers:594:17)\n    at processTimers (node:internal/timers:529:7)"
+    }
+  ],
+  "@message": "HTTP request \"GET https://example.com/api/timeout\" timed out (Error) after 300 ms",
+  "@timestamp": "2026-04-21T16:55:05.128Z",
+  "LogLevel": "error",
+  "callerContext": {
+    "loggerName": "AwsServerLogger",
+    "stack": [
+      "V.doFetch [as func] (/Users/brentrager/dev/smooai/fetch/src/fetch.ts:351:14)",
+      "/Users/brentrager/dev/smooai/fetch/src/fetch.integration.spec.ts:135:7"
+    ]
+  },
+  "context": {
+    "http": {
+      "request": {
+        "headers": {
+          "X-Correlation-Id": "602d537f-a6a5-48b7-8ad4-3b169f5d7431"
+        },
+        "hostname": "example.com",
+        "method": "GET",
+        "path": "/api/timeout",
+        "queryString": ""
+      }
+    }
+  },
+  "correlationId": "da1da40b-6f69-4e2d-adf9-2c3f4c287317",
+  "http": {
+    "request": {
+    }
+  },
+  "lambda": {
+  },
+  "level": 50,
+  "name": "AwsServerLogger",
+  "nodeEnv": "test",
+  "requestId": "da1da40b-6f69-4e2d-adf9-2c3f4c287317",
+  "traceId": "da1da40b-6f69-4e2d-adf9-2c3f4c287317"
+}
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------
+----------------------------------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -25,6 +25,11 @@
     "exports": {
         ".": {
             "types": "./dist/index.d.ts",
+            "browser": {
+                "import": "./dist/browser/index.mjs",
+                "require": "./dist/browser/index.js",
+                "default": "./dist/browser/index.js"
+            },
             "import": "./dist/index.mjs",
             "require": "./dist/index.js",
             "default": "./dist/index.js"


### PR DESCRIPTION
## Summary

- Adds `"browser"` to the `.` exports block so bundlers auto-resolve to the existing browser dist
- Consumers can `import fetch from '@smooai/fetch'` everywhere and get the right entry for the target
- Unblocks @smooai/config (removes its tsup aliasing workaround)

## Test plan

- [x] Build succeeds (tsup + python + rust + go)
- [x] Tests pass
- [ ] Downstream @smooai/config bundles produce no rotating-file-stream references

🤖 Generated with [Claude Code](https://claude.com/claude-code)