### PR TITLE
SMOODEV-662: Sync SmooAI.Fetch NuGet version to npm + polish NuGet README

### DIFF
--- a/.changeset/smoodev-662-dotnet-version-sync.md
+++ b/.changeset/smoodev-662-dotnet-version-sync.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-662: Sync SmooAI.Fetch NuGet version to package.json + polish NuGet README

--- a/dotnet/SmooAI.Fetch/README.md
+++ b/dotnet/SmooAI.Fetch/README.md
@@ -1,59 +1,66 @@
 # SmooAI.Fetch
 
-Resilient HTTP client for .NET 8+. Port of [@smooai/fetch](https://github.com/SmooAI/fetch). Built on `HttpClientFactory` + [Polly](https://github.com/App-vNext/Polly) for retry and backoff.
+**Resilient HTTP client for .NET 8+ — Polly-backed retry, typed JSON, async auth, `Retry-After` honoring, and a single typed error type for every non-2xx.**
 
-## Features
-
-- Polly-backed retry with exponential backoff + jitter
-- Honors the `Retry-After` header on 429 / 503
-- Per-request timeout via `CancellationTokenSource`
-- Typed JSON helpers: `GetAsync<T>`, `PostAsync<TReq, TRes>`, etc.
-- Async auth token provider (called per request)
-- `HttpResponseError` on non-2xx with status, body, headers, and request metadata
-- First-class `IHttpClientFactory` / DI registration
+.NET port of [`@smooai/fetch`](https://github.com/SmooAI/fetch). Built on `HttpClientFactory` + [Polly](https://github.com/App-vNext/Polly). Wire-compatible semantics with the TypeScript, Python, Go, and Rust ports.
 
 ## Install
 
-```
+```bash
 dotnet add package SmooAI.Fetch
 ```
 
-## Usage
-
-### Standalone
+## Quick start — standalone
 
 ```csharp
 using SmooAI.Fetch;
 
 var fetch = SmooFetch.Create(options =>
 {
-    options.BaseUrl = "https://api.example.com";
-    options.RetryPolicy = RetryPolicy.ExponentialBackoff(maxRetries: 3);
-    options.Timeout = TimeSpan.FromSeconds(30);
-    options.AuthTokenProvider = async ct => await GetTokenAsync(ct);
+    options.BaseUrl           = "https://api.example.com";
+    options.Timeout           = TimeSpan.FromSeconds(30);
+    options.RetryPolicy       = RetryPolicy.ExponentialBackoff(maxRetries: 3);
+    options.AuthTokenProvider = async ct => await GetBearerTokenAsync(ct);
 });
 
-var me = await fetch.GetAsync<User>("/users/me");
+var me      = await fetch.GetAsync<User>("/users/me");
 var created = await fetch.PostAsync<CreateUserDto, User>("/users", dto);
 ```
 
-### DI / HttpClientFactory
+## Quick start — DI / `IHttpClientFactory`
 
 ```csharp
 builder.Services.AddSmooFetch(options =>
 {
-    options.BaseUrl = builder.Configuration["Api:BaseUrl"];
-    options.RetryPolicy = RetryPolicy.ExponentialBackoff(maxRetries: 3);
+    options.BaseUrl           = builder.Configuration["Api:BaseUrl"];
+    options.RetryPolicy       = RetryPolicy.ExponentialBackoff(maxRetries: 3);
     options.AuthTokenProvider = _ => Task.FromResult<string?>(bearerToken);
 });
 
-// Inject:
-public class Foo(SmooFetch fetch) { ... }
+// Inject wherever you need it
+public class BillingService(SmooFetch fetch)
+{
+    public Task<Invoice> GetInvoice(string id) =>
+        fetch.GetAsync<Invoice>($"/invoices/{id}");
+}
 ```
 
-## Error handling
+## Retry policy — honors `Retry-After`
 
-Non-2xx responses throw `HttpResponseError`:
+```csharp
+options.RetryPolicy = RetryPolicy.ExponentialBackoff(
+    maxRetries:     3,
+    initialDelay:   TimeSpan.FromMilliseconds(250),
+    maxDelay:       TimeSpan.FromSeconds(10),
+    backoffFactor:  2.0,
+    jitter:         true);
+```
+
+- Retries on transient exceptions (timeouts, socket errors) and on `408` / `425` / `429` / `500` / `502` / `503` / `504`.
+- Honors the `Retry-After` header on `429` / `503` — if the server says "wait 5s", Polly waits 5s instead of your backoff.
+- Exponential backoff with jitter; bounded by `maxDelay`.
+
+## Typed errors — one `catch` per layer
 
 ```csharp
 try
@@ -62,8 +69,44 @@ try
 }
 catch (HttpResponseError ex)
 {
-    // ex.StatusCode, ex.Body, ex.Headers, ex.RequestUri
+    // ex.StatusCode  — int
+    // ex.Body        — string (response body)
+    // ex.Headers     — HttpResponseHeaders
+    // ex.RequestUri  — Uri
+    // ex.Method      — HttpMethod
 }
 ```
 
-If a retry budget is exhausted on a response-based failure, the final `HttpResponseError` is thrown by the last attempt. Transient exceptions (timeouts, socket errors) surface as the original exception type once retries are exhausted.
+`HttpResponseError` is thrown for every non-2xx response. Transient exceptions (timeouts, socket resets) surface as their original type if retries are exhausted.
+
+## Async auth token provider
+
+Auth is fetched **per request** via `AuthTokenProvider: async ct => …` — pair this with a cached/rotating token source and every call gets a fresh `Authorization` header without re-registering the client.
+
+```csharp
+options.AuthTokenProvider = async ct =>
+{
+    var token = await _tokenCache.GetOrRefreshAsync(ct);
+    return token; // null => no Authorization header on this request
+};
+```
+
+## Cancellation + per-request timeout
+
+Every method accepts a `CancellationToken`. The configured `Timeout` creates a linked `CancellationTokenSource` under the hood:
+
+```csharp
+using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+var user = await fetch.GetAsync<User>("/users/me", cancellationToken: cts.Token);
+```
+
+## Related
+
+- [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) — TypeScript / Node
+- [`smooai-fetch`](https://crates.io/crates/smooai-fetch) — Rust
+- [`smooai-fetch`](https://pypi.org/project/smooai-fetch/) — Python
+- [`github.com/SmooAI/fetch/go/fetch`](https://github.com/SmooAI/fetch/tree/main/go/fetch) — Go
+
+## License
+
+MIT — © SmooAI

--- a/dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj
+++ b/dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>SmooAI.Fetch</PackageId>
-    <Version>3.2.0</Version>
+    <Version>3.3.0</Version>
     <Authors>SmooAI</Authors>
     <Company>SmooAI</Company>
     <Description>Resilient HTTP client for .NET with Polly-based retry, timeouts, typed JSON responses, and auth token injection. Port of @smooai/fetch.</Description>


### PR DESCRIPTION
## Summary
- Bump `dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj` `<Version>` from `3.2.0` to `3.3.0` via `scripts/sync-versions.mjs` — the csproj entry already existed in the sync script; it was just stale (CI never commits back after version sync, so the csproj drifted behind npm).
- The release workflow already packs SmooAI.Fetch with Version sourced from csproj (no `-p:Version` override), so the next changeset-triggered release will publish SmooAI.Fetch 3.3.0 to nuget.org via `NUGET_API_KEY`.
- Rewrite `dotnet/SmooAI.Fetch/README.md` as a NuGet listing: hero, standalone + DI quickstarts, Polly retry policy reference (including `Retry-After` honoring), typed `HttpResponseError` example, async auth token provider docs, cancellation/timeout pattern, and sibling-language package links.

## Test plan
- [x] `node scripts/sync-versions.mjs` updates the csproj `<Version>` to match `package.json` (3.3.0).
- [x] csproj already has `<PackageReadmeFile>README.md</PackageReadmeFile>` and the `<None Include="README.md" Pack="true" ... />` item, so the new README will ride into the nupkg.
- [ ] After merge, Changesets opens the version PR; release workflow publishes SmooAI.Fetch 3.3.0 to nuget.org.

Jira: [SMOODEV-662](https://smooai.atlassian.net/browse/SMOODEV-662)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SMOODEV-662]: https://smooai.atlassian.net/browse/SMOODEV-662?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ