### PR TITLE
SMOODEV-664: Rewrite SmooAI.Fetch NuGet README — value-framed

### DIFF
--- a/.changeset/smoodev-664-readme-value-frame.md
+++ b/.changeset/smoodev-664-readme-value-frame.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-664: Rewrite the .NET (NuGet) README to value-frame the package — lead with "HTTP that gets out of your way": typed JSON, automatic retries on transient failures, auth token injection, one error type per non-2xx. Drop the "Polly-backed" implementation lead. Republishes SmooAI.Fetch with the new README.

--- a/dotnet/SmooAI.Fetch/README.md
+++ b/dotnet/SmooAI.Fetch/README.md
@@ -1,14 +1,27 @@
 # SmooAI.Fetch
 
-**Resilient HTTP client for .NET 8+ — Polly-backed retry, typed JSON, async auth, `Retry-After` honoring, and a single typed error type for every non-2xx.**
+[![NuGet](https://img.shields.io/nuget/v/SmooAI.Fetch.svg)](https://www.nuget.org/packages/SmooAI.Fetch)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-.NET port of [`@smooai/fetch`](https://github.com/SmooAI/fetch). Built on `HttpClientFactory` + [Polly](https://github.com/App-vNext/Polly). Wire-compatible semantics with the TypeScript, Python, Go, and Rust ports.
+**HTTP that gets out of your way for .NET 8+ — typed JSON in and out, automatic retry on transient failures, auth token injection, one error type for every non-2xx.**
+
+.NET port of [`@smooai/fetch`](https://github.com/SmooAI/fetch). Stop writing the same retry/backoff/auth wrapper for every API client in every service. Wire-compatible semantics with the TypeScript, Python, Go, and Rust ports.
 
 ## Install
 
 ```bash
 dotnet add package SmooAI.Fetch
 ```
+
+## What you get
+
+- **Typed JSON** — `GetAsync<User>` and `PostAsync<Dto, User>`. Your request and response shapes, strongly typed. No `JsonSerializer.Deserialize` boilerplate on every call site.
+- **Automatic retries on transient failures** — network blips, timeouts, and `408` / `425` / `429` / `5xx` responses are retried with exponential backoff + jitter.
+- **`Retry-After` is honored** — when a server tells you "wait 5s", the client waits 5s instead of your default backoff. Never eat a 429 again.
+- **Async auth tokens** — register an `AuthTokenProvider` once; every request picks up a fresh bearer token without restarting `HttpClient`.
+- **One typed error per non-2xx** — catch `HttpResponseError` and you've got status, body, headers, URI, and method on one exception.
+- **Per-request cancellation + timeout** — linked `CancellationTokenSource` under the hood; every method takes a `CancellationToken`.
+- **DI-ready** — `AddSmooFetch(options => …)` plugs into `IHttpClientFactory` and your `IServiceCollection`.
 
 ## Quick start — standalone
 
@@ -57,7 +70,7 @@ options.RetryPolicy = RetryPolicy.ExponentialBackoff(
 ```
 
 - Retries on transient exceptions (timeouts, socket errors) and on `408` / `425` / `429` / `500` / `502` / `503` / `504`.
-- Honors the `Retry-After` header on `429` / `503` — if the server says "wait 5s", Polly waits 5s instead of your backoff.
+- Honors the `Retry-After` header on `429` / `503` — if the server says "wait 5s", the client waits 5s instead of your backoff.
 - Exponential backoff with jitter; bounded by `maxDelay`.
 
 ## Typed errors — one `catch` per layer


### PR DESCRIPTION
## Summary

Rewrite `dotnet/SmooAI.Fetch/README.md` so the first scroll sells **what the package lets you do** — typed JSON in/out, automatic retry on transient failures, auth token injection, one error type per non-2xx — instead of leading with "Polly-backed retry" (plumbing).

### What changed

- **`dotnet/SmooAI.Fetch/README.md`** — new value-frame lead + NuGet / license badges; added a "What you get" bullet block; rewrote the retry section so it describes **behavior** (retries on transient exceptions + 5xx, honors `Retry-After`, exponential backoff with jitter) rather than Polly internals. Root + Python/Rust/Go READMEs already lead with value; unchanged in this PR.
- **`.changeset/smoodev-664-readme-value-frame.md`** — patch bump so SmooAI.Fetch republishes on NuGet with the new README.

## Test plan

- [x] `pnpm lint` + `pnpm typecheck` + `pnpm test` (TS + Python + Rust + Go + .NET 8) + `pnpm build` + `pnpm format` via pre-commit hook
- [x] Verified `dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj` still has `<PackageReadmeFile>README.md</PackageReadmeFile>` + `<None Include="README.md" Pack="true" PackagePath="\" />`
- [ ] Merge triggers changesets release → new SmooAI.Fetch version on NuGet with the new README

Jira: [SMOODEV-664](https://smooai.atlassian.net/browse/SMOODEV-664)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SMOODEV-664]: https://smooai.atlassian.net/browse/SMOODEV-664?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ