### PR TITLE
SMOODEV-666: Multi-target SmooAI.Fetch to net8.0;net9.0;net10.0

### DIFF
--- a/.changeset/smoodev-666-multi-target.md
+++ b/.changeset/smoodev-666-multi-target.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-666: Multi-target the SmooAI.Fetch NuGet package to `net8.0;net9.0;net10.0` so consumers on every current .NET LTS + STS release get a native `lib/` folder match. Polly v8, Microsoft.Extensions.Http, and Microsoft.Extensions.Http.Polly all resolve cleanly on all three TFMs — no per-TFM conditionals needed.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -49,7 +49,10 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '8.0.x'
+                  dotnet-version: |
+                      8.0.x
+                      9.0.x
+                      10.0.x
 
             - name: Install dependencies
               run: pnpm install

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,10 @@ jobs:
             - name: Setup .NET
               uses: actions/setup-dotnet@v4
               with:
-                  dotnet-version: '8.0.x'
+                  dotnet-version: |
+                      8.0.x
+                      9.0.x
+                      10.0.x
 
             - name: Install dependencies
               run: pnpm install

--- a/dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj
+++ b/dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>


### PR DESCRIPTION
## Summary
- Expand `SmooAI.Fetch.csproj`'s `<TargetFrameworks>` from single-value `net8.0` to `net8.0;net9.0;net10.0` so the NuGet package ships `lib/net{8,9,10}.0/SmooAI.Fetch.dll` and consumers on every current .NET LTS + STS release get a native match.
- `Polly 8.5.0`, `Microsoft.Extensions.Http 8.0.1`, `Microsoft.Extensions.Http.Polly 8.0.11`, and `Microsoft.Extensions.Logging.Abstractions 8.0.2` all resolve cleanly on all three TFMs — no per-TFM conditional needed.
- Update both .NET CI workflows (pr-checks, release) to install 8.0.x + 9.0.x + 10.0.x SDKs so the multi-target build resolves on the runner.

## Test plan
- [x] `dotnet restore` — resolves on all three TFMs locally
- [x] `dotnet build -c Release` — succeeds for net8.0, net9.0, net10.0 (3 DLLs produced)
- [x] `dotnet test -c Release` — Fetch.Tests 20/20 pass (net8.0)
- [x] `dotnet pack` — inspected nupkg; contains `lib/net{8,9,10}.0/SmooAI.Fetch.dll`
- [x] Pre-commit hook (lint, typecheck, test, build, format) passed
- [ ] PR CI (ubuntu) green

🤖 Generated with [Claude Code](https://claude.com/claude-code)