### PR TITLE
SMOODEV-667: Fix release pipeline — clean stale Python dist + drop --locked

### DIFF
--- a/.changeset/smoodev-667-publish-pipeline.md
+++ b/.changeset/smoodev-667-publish-pipeline.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-667: Fix release pipeline so PyPI + crates.io + NuGet actually publish. `pnpm build` produces a Python wheel at the pre-sync version (the Cargo/pyproject bumps happen later, inside `ci:publish`), so the publish step was trying to re-upload the stale wheel and getting rejected. Clean `dist/` before `uv run poe publish` so only the freshly-built version ships. Drop `--locked` from the cargo publish step because sync-versions only updates `Cargo.toml` (not `Cargo.lock`), which would trip `--locked` as soon as crates.io is reached. Net effect: `SmooAI.Fetch` NuGet package publishes for the first time; PyPI advances from the stalled 3.0.0.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -105,17 +105,25 @@ jobs:
 
             - name: Publish smooai-fetch to PyPI
               if: steps.changesets.outputs.published == 'true'
-              run: uv run poe publish
               working-directory: python
               env:
                   UV_PUBLISH_TOKEN: ${{ secrets.SMOOAI_PYPI_TOKEN }}
+              run: |
+                  # Clean stale build artifacts from the earlier `pnpm build` run
+                  # (which produced wheels at the pre-sync version) so `uv publish`
+                  # doesn't try to upload the stale files alongside the fresh ones.
+                  rm -rf dist/
+                  uv run poe publish
 
             - name: Publish smooai-fetch to crates.io
               if: steps.changesets.outputs.published == 'true'
               uses: actions-rs/cargo@v1
               with:
                   command: publish
-                  args: --locked --manifest-path rust/fetch/Cargo.toml
+                  # --allow-dirty is needed because sync-versions.mjs modifies
+                  # Cargo.toml (and rebuild updates Cargo.lock) between the
+                  # committed state and publish. --locked would reject that mismatch.
+                  args: --allow-dirty --manifest-path rust/fetch/Cargo.toml
               env:
                   CARGO_REGISTRY_TOKEN: ${{ secrets.SMOOAI_CARGO_REGISTRY_TOKEN }}
 


### PR DESCRIPTION
## Summary
- `pnpm build` runs during `ci:publish` BEFORE `sync-versions.mjs` updates `python/pyproject.toml`, so it produces a wheel at the pre-bump version (`smooai_fetch-2.1.2-*` most recently). Then the publish step re-runs `uv build` at the new version (3.3.2+), but the old wheel is still in `dist/`, and `uv publish` uploads all four files. PyPI rejects the stale 2.1.2 wheel (`400 File already exists`) and `poe`'s sequence runner aborts the entire workflow before .NET NuGet can publish — which is why `SmooAI.Fetch` is still unpublished on nuget.org.
- Clean `dist/` before `uv run poe publish` so only fresh files ship.
- Also drop `--locked` from the cargo publish step. `sync-versions.mjs` updates `Cargo.toml` but not `Cargo.lock`, which would trip `--locked` as soon as PyPI starts succeeding and crates.io becomes reachable. This matches the pattern already used in the logger repo.

## Why this unblocks NuGet
The release workflow runs PyPI BEFORE NuGet and has no `continue-on-error` guard, so a 400 from PyPI aborts the whole job. Fixing PyPI (and pre-emptively fixing the `--locked` issue waiting behind it) lets the pipeline reach the NuGet publish step for the first time.

## Follow-up (not in this PR)
SMOODEV-667 description proposes a resilience follow-up: restructure `release.yml` so each registry publish is isolated (continue-on-error or parallel jobs) and one registry's rejection can't hold up the others.

## Verification
- [ ] Release workflow completes through NuGet publish step on this PR's merge
- [ ] `curl -s https://api.nuget.org/v3-flatcontainer/smooai.fetch/index.json` shows the new version on nuget.org (first-ever publish)
- [ ] `curl -s https://pypi.org/pypi/smooai-fetch/json | jq -r .info.version` advances past the stalled 3.0.0
- [ ] `npm view @smooai/fetch version` matches the new synced version

🤖 Generated with [Claude Code](https://claude.com/claude-code)