### PR TITLE
SMOODEV-928: Bump @smooai/logger to ^4.1.4 + @smooai/utils to ^1.3.3

### DIFF
--- a/.changeset/bump-logger-utils.md
+++ b/.changeset/bump-logger-utils.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-928: Bump `@smooai/logger` to `^4.1.4` and `@smooai/utils` to `^1.3.3`. Picks up the ESM `__filename` TDZ fix from logger 4.1.4 across the runtime dep graph (utils itself was on logger 3.x prior to 1.3.3). Also drops the deprecated `baseUrl: "./"` from tsconfig (TS 5.9+/6.x emit TS5101 with `ignoreDeprecations: "5.0"`); fetch has no `paths` entries so this is a no-op for type resolution.

--- a/package.json
+++ b/package.json
@@ -96,8 +96,8 @@
     },
     "dependencies": {
         "@faker-js/faker": "^9.6.0",
-        "@smooai/logger": "^3.1.2",
-        "@smooai/utils": "^1.3.2",
+        "@smooai/logger": "^4.1.4",
+        "@smooai/utils": "^1.3.3",
         "@standard-schema/spec": "^1.0.0",
         "@standard-schema/utils": "^0.3.0",
         "lodash.merge": "^4.6.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,11 +13,11 @@ importers:
         specifier: ^9.6.0
         version: 9.6.0
       '@smooai/logger':
-        specifier: ^3.1.2
-        version: 3.1.2
+        specifier: ^4.1.4
+        version: 4.1.4
       '@smooai/utils':
-        specifier: ^1.3.2
-        version: 1.3.2(@types/node@22.13.10)(typescript@5.8.2)
+        specifier: ^1.3.3
+        version: 1.3.3(@types/node@22.13.10)(typescript@5.8.2)
       '@standard-schema/spec':
         specifier: ^1.0.0
         version: 1.0.0
@@ -1138,12 +1138,13 @@ packages:
     peerDependencies:
       typescript: ^5.8.2
 
-  '@smooai/logger@3.1.2':
-    resolution: {integrity: sha512-8vdExXzswbr5wnzs++u9ZI/NAbTuz9A/iFPoPNNzZgNlXeFujPEA7ZvSCF6q57PfEdjvDRMTeF00/2dseQDCDQ==}
+  '@smooai/logger@4.1.4':
+    resolution: {integrity: sha512-ub+dYF38oE8Ke3BNz1FmpfjlCKBOGzf+KQPI4ZIvTu34gckEBG2D7ISxq0Lnp4hN/xMi0v/LRnxjgGiDUtmaZQ==}
     engines: {node: '>=20.0.0'}
+    hasBin: true
 
-  '@smooai/utils@1.3.2':
-    resolution: {integrity: sha512-OvXXcrXNH61m3udK1G0rTkSjp2dTAfRMHdfLL1NuF/wT7ld4PvuLEN1GRd7n5M+OHhqpE9WSwNx+qdXhMCEiYQ==}
+  '@smooai/utils@1.3.3':
+    resolution: {integrity: sha512-oC+yXM37uZnJSD7Lk0sxW4cZjW+GIprdS/v8/63alavuPrUELK5c6WljZR1TRuzAan4afHkHRKDl8eK3xRHuKA==}
     engines: {node: '>=20.0.0'}
     hasBin: true
 
@@ -2449,6 +2450,7 @@ packages:
 
   uuid@9.0.1:
     resolution: {integrity: sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==}
+    deprecated: uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).
     hasBin: true
 
   v8-compile-cache-lib@3.0.1:
@@ -3936,7 +3938,7 @@ snapshots:
     dependencies:
       typescript: 5.8.2
 
-  '@smooai/logger@3.1.2':
+  '@smooai/logger@4.1.4':
     dependencies:
       '@aws-sdk/client-sqs': 3.893.0
       browser-dtector: 4.1.0
@@ -3954,12 +3956,12 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
 
-  '@smooai/utils@1.3.2(@types/node@22.13.10)(typescript@5.8.2)':
+  '@smooai/utils@1.3.3(@types/node@22.13.10)(typescript@5.8.2)':
     dependencies:
       '@oclif/core': 2.16.0(@types/node@22.13.10)(typescript@5.8.2)
       '@oclif/plugin-help': 6.2.33
       '@oclif/plugin-plugins': 5.4.47
-      '@smooai/logger': 3.1.2
+      '@smooai/logger': 4.1.4
       '@standard-schema/spec': 1.0.0
       '@standard-schema/utils': 0.3.0
       find-up: 7.0.0

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,8 +4,7 @@
         "lib": ["ES2023"],
         "outDir": "./dist",
         "types": ["node"],
-        "target": "ES2022",
-        "baseUrl": "./"
+        "target": "ES2022"
     },
     "include": ["./src/**/*.ts", "./src/**/*.tsx", "tsup.config.ts"],
     "exclude": ["dist", "node_modules", "*.js", "../../node_modules"]


### PR DESCRIPTION
## Summary
- Bump runtime \`@smooai/logger\` to \`^4.1.4\` and \`@smooai/utils\` to \`^1.3.3\` (now that utils 1.3.3 ships with the same logger 4.x bump).
- Drop deprecated \`baseUrl: "./"\` from tsconfig — TS 5.9+/6.x reject \`baseUrl + ignoreDeprecations: "5.0"\` with TS5101. fetch has no paths entries that need it.

## Test plan
- [x] \`tsc --noEmit --skipLibCheck\` clean
- [x] vitest 44 tests pass (2 files)
- [x] python:typecheck, rust:check, dotnet build/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)