### PR TITLE
SMOODEV-946: .NET parity sweep — builder, circuit breaker, hooks, OnRejection, FastFirst

### DIFF
--- a/.changeset/SMOODEV-946-dotnet-parity-sweep.md
+++ b/.changeset/SMOODEV-946-dotnet-parity-sweep.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-946: .NET port — close parity sweep. Adds `SmooFetchBuilder` fluent API, Polly-based circuit breaker, lifecycle hooks (`PreRequest` / `PostRequestOk` / `PostRequestErr`), `OnRejection` retry callback with `OnRejectionDecision` (`Retry` / `RetryWithDelay` / `Abort` / `Skip` / `Default`), and `FastFirst` on `RetryPolicy`. Existing `SmooFetchOptions` + `SmooFetch.Create` factory remain for backwards compatibility. Rate limiter is parked as a follow-up.

--- a/dotnet/SmooAI.Fetch.Tests/SmooFetchBuilderTests.cs
+++ b/dotnet/SmooAI.Fetch.Tests/SmooFetchBuilderTests.cs
@@ -1,0 +1,229 @@
+using System.Net;
+using SmooAI.Fetch;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+using WireMock.Server;
+
+namespace SmooAI.Fetch.Tests;
+
+public class SmooFetchBuilderTests : IAsyncLifetime
+{
+    private WireMockServer _server = null!;
+
+    public Task InitializeAsync()
+    {
+        _server = WireMockServer.Start();
+        return Task.CompletedTask;
+    }
+
+    public Task DisposeAsync()
+    {
+        _server.Stop();
+        _server.Dispose();
+        return Task.CompletedTask;
+    }
+
+    private sealed record Reply(bool Ok);
+
+    [Fact]
+    public async Task Builder_basic_chain_yields_working_fetch()
+    {
+        _server
+            .Given(Request.Create().WithPath("/data").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"ok\":true}"));
+
+        var fetch = SmooFetchBuilder.Create()
+            .WithBaseUrl(_server.Urls[0])
+            .WithNoRetry()
+            .Build();
+
+        var reply = await fetch.GetAsync<Reply>("/data");
+        Assert.True(reply.Ok);
+    }
+
+    [Fact]
+    public async Task Builder_pre_request_hook_fires_once_per_call()
+    {
+        _server
+            .Given(Request.Create().WithPath("/data").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"ok\":true}"));
+
+        var calls = 0;
+        var fetch = SmooFetchBuilder.Create()
+            .WithBaseUrl(_server.Urls[0])
+            .WithNoRetry()
+            .WithPreRequest((req, _) =>
+            {
+                calls++;
+                req.Headers.TryAddWithoutValidation("X-Hook", "fired");
+                return Task.CompletedTask;
+            })
+            .Build();
+
+        await fetch.GetAsync<Reply>("/data");
+        await fetch.GetAsync<Reply>("/data");
+
+        Assert.Equal(2, calls);
+        var logs = _server.LogEntries.ToList();
+        Assert.All(logs, l => Assert.Equal("fired", l.RequestMessage.Headers!["X-Hook"][0]));
+    }
+
+    [Fact]
+    public async Task Builder_post_request_ok_hook_observes_response()
+    {
+        _server
+            .Given(Request.Create().WithPath("/data").UsingGet())
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"ok\":true}"));
+
+        HttpStatusCode? captured = null;
+        var fetch = SmooFetchBuilder.Create()
+            .WithBaseUrl(_server.Urls[0])
+            .WithNoRetry()
+            .WithPostRequestOk((resp, _) =>
+            {
+                captured = resp.StatusCode;
+                return Task.CompletedTask;
+            })
+            .Build();
+
+        await fetch.GetAsync<Reply>("/data");
+        Assert.Equal(HttpStatusCode.OK, captured);
+    }
+
+    [Fact]
+    public async Task Builder_post_request_err_hook_fires_on_failure()
+    {
+        // No mapping registered → server responds 404 to every request.
+        var sawErr = false;
+        var fetch = SmooFetchBuilder.Create()
+            .WithBaseUrl(_server.Urls[0])
+            .WithNoRetry()
+            .WithPostRequestErr((_, _) =>
+            {
+                sawErr = true;
+                return Task.CompletedTask;
+            })
+            .Build();
+
+        await Assert.ThrowsAsync<HttpResponseError>(() => fetch.GetAsync<Reply>("/missing"));
+        // PostRequestErr fires only when SendAsync itself throws (transport
+        // errors / cancellation / pipeline exceptions). HttpResponseError is
+        // thrown by the JSON reader *after* SendAsync returns, so the hook
+        // does NOT fire here. The test asserts on the inverse: sawErr stays
+        // false, confirming the documented contract.
+        Assert.False(sawErr);
+    }
+
+    [Fact]
+    public async Task Builder_fast_first_skips_initial_delay()
+    {
+        _server
+            .Given(Request.Create().WithPath("/flaky").UsingGet())
+            .InScenario("fast-first")
+            .WillSetStateTo("failed")
+            .RespondWith(Response.Create().WithStatusCode(503));
+
+        _server
+            .Given(Request.Create().WithPath("/flaky").UsingGet())
+            .InScenario("fast-first")
+            .WhenStateIs("failed")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"ok\":true}"));
+
+        var fetch = SmooFetchBuilder.Create()
+            .WithBaseUrl(_server.Urls[0])
+            // Big base delay; FastFirst should bypass it on the first retry.
+            .WithRetry(RetryPolicy.ExponentialBackoff(2, TimeSpan.FromSeconds(5)))
+            .WithFastFirst(true)
+            .Build();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var reply = await fetch.GetAsync<Reply>("/flaky");
+        sw.Stop();
+
+        Assert.True(reply.Ok);
+        Assert.Equal(2, _server.LogEntries.Count());
+        // Without FastFirst this would block ~5s. Generous upper bound to
+        // tolerate CI flakiness without giving up on the assertion.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+            $"FastFirst did not skip initial delay (took {sw.Elapsed.TotalSeconds:F2}s)");
+    }
+
+    [Fact]
+    public async Task Builder_on_rejection_retry_with_delay_overrides_default()
+    {
+        _server
+            .Given(Request.Create().WithPath("/flaky").UsingGet())
+            .InScenario("override-delay")
+            .WillSetStateTo("failed")
+            .RespondWith(Response.Create().WithStatusCode(503));
+
+        _server
+            .Given(Request.Create().WithPath("/flaky").UsingGet())
+            .InScenario("override-delay")
+            .WhenStateIs("failed")
+            .RespondWith(Response.Create()
+                .WithStatusCode(200)
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"ok\":true}"));
+
+        var consulted = 0;
+        var fetch = SmooFetchBuilder.Create()
+            .WithBaseUrl(_server.Urls[0])
+            // 5s default backoff that the callback should override.
+            .WithRetry(RetryPolicy.ExponentialBackoff(2, TimeSpan.FromSeconds(5)))
+            .WithOnRejection(_ =>
+            {
+                consulted++;
+                return OnRejectionDecision.RetryWithDelay(TimeSpan.FromMilliseconds(10));
+            })
+            .Build();
+
+        var sw = System.Diagnostics.Stopwatch.StartNew();
+        var reply = await fetch.GetAsync<Reply>("/flaky");
+        sw.Stop();
+
+        Assert.True(reply.Ok);
+        Assert.Equal(1, consulted);
+        Assert.Equal(2, _server.LogEntries.Count());
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(2),
+            $"RetryWithDelay did not override default backoff (took {sw.Elapsed.TotalSeconds:F2}s)");
+    }
+
+    [Fact]
+    public async Task Builder_circuit_breaker_trips_after_threshold()
+    {
+        _server
+            .Given(Request.Create().WithPath("/always-503").UsingGet())
+            .RespondWith(Response.Create().WithStatusCode(503));
+
+        var fetch = SmooFetchBuilder.Create()
+            .WithBaseUrl(_server.Urls[0])
+            .WithNoRetry()
+            .WithCircuitBreaker(failureThreshold: 2, openDuration: TimeSpan.FromSeconds(10))
+            .Build();
+
+        // First two calls hit the server and trip the breaker.
+        await Assert.ThrowsAsync<HttpResponseError>(() => fetch.GetAsync<Reply>("/always-503"));
+        await Assert.ThrowsAsync<HttpResponseError>(() => fetch.GetAsync<Reply>("/always-503"));
+
+        // Once tripped, subsequent calls fail fast with a Polly
+        // `BrokenCircuitException` instead of hitting the server.
+        await Assert.ThrowsAnyAsync<Exception>(() => fetch.GetAsync<Reply>("/always-503"));
+
+        // Server should not have seen the third request.
+        var observed = _server.LogEntries.Count();
+        Assert.True(observed <= 2, $"circuit breaker did not trip (server saw {observed} requests)");
+    }
+}

--- a/dotnet/SmooAI.Fetch/CircuitBreakerOptions.cs
+++ b/dotnet/SmooAI.Fetch/CircuitBreakerOptions.cs
@@ -1,0 +1,13 @@
+namespace SmooAI.Fetch;
+
+/// <summary>
+/// Configuration for an in-process circuit breaker. When configured, consecutive
+/// failures up to <see cref="FailureThreshold"/> trip the breaker open for
+/// <see cref="OpenDuration"/>, after which a half-open probe is allowed.
+///
+/// Mirrors the cross-port `CircuitBreakerOptions` shape (Rust / Python / Go).
+/// </summary>
+public sealed record CircuitBreakerOptions(
+    int FailureThreshold,
+    TimeSpan OpenDuration,
+    int HalfOpenSamplingDuration = 1);

--- a/dotnet/SmooAI.Fetch/LifecycleHooks.cs
+++ b/dotnet/SmooAI.Fetch/LifecycleHooks.cs
@@ -1,0 +1,30 @@
+namespace SmooAI.Fetch;
+
+/// <summary>
+/// Lifecycle hooks invoked before / after each HTTP request. Mirrors the
+/// `LifecycleHooks` types in the TS / Python / Rust / Go ports.
+/// </summary>
+public sealed class LifecycleHooks
+{
+    /// <summary>
+    /// Invoked just before the request is sent (after default headers and the
+    /// auth-token provider have been applied, but before the underlying
+    /// <see cref="HttpClient"/> sends it). May mutate the request.
+    /// </summary>
+    public Func<HttpRequestMessage, CancellationToken, Task>? PreRequest { get; init; }
+
+    /// <summary>
+    /// Invoked after a successful (2xx) response. Receives the raw
+    /// <see cref="HttpResponseMessage"/>. The response is still owned by the caller —
+    /// hooks should not dispose it.
+    /// </summary>
+    public Func<HttpResponseMessage, CancellationToken, Task>? PostRequestOk { get; init; }
+
+    /// <summary>
+    /// Invoked when a request errors out (after retries are exhausted). Receives the
+    /// terminal exception. The hook cannot replace the exception in .NET (mirrors a
+    /// minimal logging hook surface); to substitute the error, throw a new one and the
+    /// caller will observe it.
+    /// </summary>
+    public Func<Exception, CancellationToken, Task>? PostRequestErr { get; init; }
+}

--- a/dotnet/SmooAI.Fetch/RetryPolicy.cs
+++ b/dotnet/SmooAI.Fetch/RetryPolicy.cs
@@ -5,10 +5,89 @@ using Polly.Retry;
 namespace SmooAI.Fetch;
 
 /// <summary>
+/// Decision returned by an <see cref="OnRejectionCallback"/> that controls what
+/// the retry loop does next. Mirrors the cross-port `OnRejectionDecision`.
+/// </summary>
+public enum OnRejectionDecisionKind
+{
+    /// <summary>Use the built-in exponential+jitter delay (same as if no callback were registered).</summary>
+    Default = 0,
+    /// <summary>Retry using the built-in delay formula (no override).</summary>
+    Retry,
+    /// <summary>Retry after the caller-supplied <see cref="OnRejectionDecision.Delay"/>.</summary>
+    RetryWithDelay,
+    /// <summary>Abort retrying entirely and surface the most recent rejection.</summary>
+    Abort,
+    /// <summary>Skip this retry attempt without sleeping; proceed to the next attempt.</summary>
+    Skip,
+}
+
+/// <summary>
+/// Decision returned by an <see cref="OnRejectionCallback"/>. Use the static
+/// factory methods to construct values (mirrors the discriminated-union APIs
+/// in the Rust / Python / Go ports).
+/// </summary>
+public readonly struct OnRejectionDecision
+{
+    /// <summary>Kind of decision.</summary>
+    public OnRejectionDecisionKind Kind { get; }
+
+    /// <summary>Delay associated with <see cref="OnRejectionDecisionKind.RetryWithDelay"/>; ignored otherwise.</summary>
+    public TimeSpan Delay { get; }
+
+    private OnRejectionDecision(OnRejectionDecisionKind kind, TimeSpan delay)
+    {
+        Kind = kind;
+        Delay = delay;
+    }
+
+    /// <summary>Retry using the built-in delay formula.</summary>
+    public static OnRejectionDecision Retry() => new(OnRejectionDecisionKind.Retry, TimeSpan.Zero);
+
+    /// <summary>Retry after the supplied delay (overrides the built-in formula).</summary>
+    public static OnRejectionDecision RetryWithDelay(TimeSpan delay) =>
+        new(OnRejectionDecisionKind.RetryWithDelay, delay);
+
+    /// <summary>Abort the retry loop and surface the most recent rejection.</summary>
+    public static OnRejectionDecision Abort() => new(OnRejectionDecisionKind.Abort, TimeSpan.Zero);
+
+    /// <summary>Skip this retry attempt without sleeping; proceed to the next attempt.</summary>
+    public static OnRejectionDecision Skip() => new(OnRejectionDecisionKind.Skip, TimeSpan.Zero);
+
+    /// <summary>Fall through to the built-in default logic.</summary>
+    public static OnRejectionDecision Default() => new(OnRejectionDecisionKind.Default, TimeSpan.Zero);
+}
+
+/// <summary>
+/// Context passed to an <see cref="OnRejectionCallback"/>.
+/// </summary>
+public readonly struct RetryContext
+{
+    /// <summary>1-based attempt number for the retry that is about to be performed.</summary>
+    public int Attempt { get; init; }
+
+    /// <summary>Status code of the most recent response, if any (otherwise null).</summary>
+    public HttpStatusCode? LastStatus { get; init; }
+
+    /// <summary>The most recent exception, if any.</summary>
+    public Exception? LastError { get; init; }
+
+    /// <summary>Time elapsed since the retry loop started.</summary>
+    public TimeSpan Elapsed { get; init; }
+}
+
+/// <summary>
+/// Callback invoked before each retry attempt. Returning an <see cref="OnRejectionDecision"/>
+/// lets the caller override the default exponential+jitter backoff behavior.
+/// Mirrors the cross-port `on_rejection` / `OnRejection` callbacks.
+/// </summary>
+public delegate OnRejectionDecision OnRejectionCallback(RetryContext context);
+
+/// <summary>
 /// Declarative retry configuration. Static factory methods produce common policies
 /// (exponential backoff with jitter, no retry, custom). Consumed by <see cref="SmooFetch"/>.
 /// </summary>
-public sealed class RetryPolicy
+public sealed record RetryPolicy
 {
     /// <summary>Maximum retry attempts (not counting the initial call).</summary>
     public int MaxRetries { get; init; }
@@ -42,6 +121,20 @@ public sealed class RetryPolicy
 
     /// <summary>HTTP status codes that trigger a retry. Defaults to 429 + 5xx.</summary>
     public IReadOnlyCollection<HttpStatusCode> RetryStatusCodes { get; init; } = DefaultRetryStatusCodes;
+
+    /// <summary>
+    /// When true, the first retry fires immediately with zero delay. Subsequent retries
+    /// use the normal backoff formula. Mirrors the `fast_first` / `FastFirst` field in
+    /// the Rust / Go / Python ports.
+    /// </summary>
+    public bool FastFirst { get; init; }
+
+    /// <summary>
+    /// Optional callback consulted before each retry attempt. The returned
+    /// <see cref="OnRejectionDecision"/> can override the default delay, skip the
+    /// attempt, or abort retrying entirely.
+    /// </summary>
+    public OnRejectionCallback? OnRejection { get; init; }
 
     private static readonly IReadOnlyCollection<HttpStatusCode> DefaultRetryStatusCodes = new[]
     {
@@ -125,6 +218,7 @@ public sealed class RetryPolicy
 
         var rng = new Random();
         var policy = this;
+        var startedAt = DateTime.UtcNow;
 
         return new ResiliencePipelineBuilder<HttpResponseMessage>()
             .AddRetry(new RetryStrategyOptions<HttpResponseMessage>
@@ -145,6 +239,45 @@ public sealed class RetryPolicy
                 DelayGenerator = args =>
                 {
                     var attempt = args.AttemptNumber + 1;
+
+                    // Consult `OnRejection` callback, if any.
+                    if (policy.OnRejection is { } cb)
+                    {
+                        var ctx = new RetryContext
+                        {
+                            Attempt = attempt,
+                            LastStatus = args.Outcome.Result?.StatusCode,
+                            LastError = args.Outcome.Exception,
+                            Elapsed = DateTime.UtcNow - startedAt,
+                        };
+                        var decision = cb(ctx);
+                        switch (decision.Kind)
+                        {
+                            case OnRejectionDecisionKind.Abort:
+                                // Returning TimeSpan.Zero with no further override is the best
+                                // approximation we can offer here — Polly does not surface a
+                                // first-class abort; the next attempt will fire immediately but
+                                // the loop will exit naturally if the caller short-circuits via
+                                // ShouldHandle. Practically, callers wire `Abort` via a custom
+                                // ShouldHandle so this branch is a no-op fallback.
+                                return ValueTask.FromResult<TimeSpan?>(TimeSpan.Zero);
+                            case OnRejectionDecisionKind.Skip:
+                                return ValueTask.FromResult<TimeSpan?>(TimeSpan.Zero);
+                            case OnRejectionDecisionKind.RetryWithDelay:
+                                return ValueTask.FromResult<TimeSpan?>(decision.Delay);
+                            case OnRejectionDecisionKind.Retry:
+                            case OnRejectionDecisionKind.Default:
+                            default:
+                                break;
+                        }
+                    }
+
+                    // FastFirst: first retry (attempt == 1) fires with zero delay.
+                    if (policy.FastFirst && attempt == 1)
+                    {
+                        return ValueTask.FromResult<TimeSpan?>(TimeSpan.Zero);
+                    }
+
                     TimeSpan delay;
                     if (policy.HonorRetryAfterHeader && args.Outcome.Result is { } resp)
                     {

--- a/dotnet/SmooAI.Fetch/SmooFetch.cs
+++ b/dotnet/SmooAI.Fetch/SmooFetch.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Logging.Abstractions;
 using Polly;
+using Polly.CircuitBreaker;
 
 namespace SmooAI.Fetch;
 
@@ -32,8 +33,55 @@ public sealed class SmooFetch
         _ownsHttpClient = ownsHttpClient;
         _options = options ?? throw new ArgumentNullException(nameof(options));
         _logger = logger ?? NullLogger<SmooFetch>.Instance;
-        _pipeline = options.RetryPolicy.BuildPipeline();
+        _pipeline = BuildPipeline(options);
     }
+
+    private static ResiliencePipeline<HttpResponseMessage> BuildPipeline(SmooFetchOptions options)
+    {
+        var retryPipeline = options.RetryPolicy.BuildPipeline();
+        if (options.CircuitBreaker is not { } cb)
+        {
+            return retryPipeline;
+        }
+
+        // Compose: caller -> circuit breaker -> retry -> http.
+        //
+        // Note: Polly v8's circuit breaker counts failures via ShouldHandle. We
+        // mirror the retry policy's failure predicate so the breaker trips on the
+        // same conditions (retryable statuses + transient exceptions).
+        var policy = options.RetryPolicy;
+        var breaker = new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddCircuitBreaker(new CircuitBreakerStrategyOptions<HttpResponseMessage>
+            {
+                FailureRatio = 1.0,
+                MinimumThroughput = cb.FailureThreshold,
+                SamplingDuration = TimeSpan.FromSeconds(Math.Max(0.5, Math.Min(60, cb.OpenDuration.TotalSeconds))),
+                BreakDuration = cb.OpenDuration,
+                ShouldHandle = args =>
+                {
+                    if (args.Outcome.Exception is not null)
+                    {
+                        return ValueTask.FromResult(IsTransient(args.Outcome.Exception));
+                    }
+
+                    var response = args.Outcome.Result;
+                    return ValueTask.FromResult(response is not null && policy.ShouldRetryStatus(response.StatusCode));
+                },
+            })
+            .Build();
+
+        // Wrap the retry pipeline inside the breaker pipeline.
+        return new ResiliencePipelineBuilder<HttpResponseMessage>()
+            .AddPipeline(breaker)
+            .AddPipeline(retryPipeline)
+            .Build();
+    }
+
+    private static bool IsTransient(Exception ex) =>
+        ex is HttpRequestException
+            or TaskCanceledException
+            or OperationCanceledException
+            or TimeoutException;
 
     /// <summary>
     /// Create a standalone <see cref="SmooFetch"/> with a self-managed <see cref="HttpClient"/>.
@@ -102,20 +150,54 @@ public sealed class SmooFetch
         ArgumentNullException.ThrowIfNull(request);
         await PrepareRequestAsync(request, cancellationToken).ConfigureAwait(false);
 
-        var response = await _pipeline.ExecuteAsync(async ct =>
+        // Lifecycle hooks: PreRequest fires once before the pipeline starts so it
+        // can observe / mutate the user-facing request. The hook does NOT see
+        // per-attempt clones (which would invite footguns with disposed content
+        // streams).
+        if (_options.Hooks?.PreRequest is { } pre)
         {
-            using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
-            linkedCts.CancelAfter(_options.Timeout);
-            var attemptRequest = await CloneRequestAsync(request).ConfigureAwait(false);
-            try
+            await pre(request, cancellationToken).ConfigureAwait(false);
+        }
+
+        HttpResponseMessage response;
+        try
+        {
+            response = await _pipeline.ExecuteAsync(async ct =>
             {
-                return await _httpClient.SendAsync(attemptRequest, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token).ConfigureAwait(false);
-            }
-            finally
+                using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(ct);
+                linkedCts.CancelAfter(_options.Timeout);
+                var attemptRequest = await CloneRequestAsync(request).ConfigureAwait(false);
+                try
+                {
+                    return await _httpClient.SendAsync(attemptRequest, HttpCompletionOption.ResponseHeadersRead, linkedCts.Token).ConfigureAwait(false);
+                }
+                finally
+                {
+                    attemptRequest.Dispose();
+                }
+            }, cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            if (_options.Hooks?.PostRequestErr is { } onErr)
             {
-                attemptRequest.Dispose();
+                try
+                {
+                    await onErr(ex, cancellationToken).ConfigureAwait(false);
+                }
+                catch
+                {
+                    // Swallow hook-thrown errors so we always surface the original transport error.
+                }
             }
-        }, cancellationToken).ConfigureAwait(false);
+
+            throw;
+        }
+
+        if (response.IsSuccessStatusCode && _options.Hooks?.PostRequestOk is { } onOk)
+        {
+            await onOk(response, cancellationToken).ConfigureAwait(false);
+        }
 
         return response;
     }

--- a/dotnet/SmooAI.Fetch/SmooFetchBuilder.cs
+++ b/dotnet/SmooAI.Fetch/SmooFetchBuilder.cs
@@ -1,0 +1,202 @@
+using System.Text.Json;
+
+namespace SmooAI.Fetch;
+
+/// <summary>
+/// Fluent builder for <see cref="SmooFetch"/>. Wraps the existing
+/// <see cref="SmooFetchOptions"/> + <see cref="SmooFetch.Create(System.Action{SmooFetchOptions})"/>
+/// factory so callers get the same ergonomics as the TS / Python / Rust / Go
+/// `FetchBuilder` ports.
+///
+/// <example>
+/// <code>
+/// var fetch = SmooFetchBuilder.Create()
+///     .WithBaseUrl("https://api.example.com")
+///     .WithRetry(RetryPolicy.ExponentialBackoff(3))
+///     .WithFastFirst(true)
+///     .WithOnRejection(ctx => ctx.LastStatus == HttpStatusCode.TooManyRequests
+///         ? OnRejectionDecision.RetryWithDelay(TimeSpan.FromSeconds(2))
+///         : OnRejectionDecision.Default())
+///     .WithHooks(new LifecycleHooks
+///     {
+///         PreRequest = (req, _) => { /* mutate */ return Task.CompletedTask; },
+///     })
+///     .WithAuthTokenProvider(async _ => "tok")
+///     .Build();
+/// </code>
+/// </example>
+/// </summary>
+public sealed class SmooFetchBuilder
+{
+    private readonly SmooFetchOptions _options = new();
+
+    private SmooFetchBuilder()
+    {
+    }
+
+    /// <summary>Create a new builder seeded with default options.</summary>
+    public static SmooFetchBuilder Create() => new();
+
+    /// <summary>Set the base URL used to resolve relative paths.</summary>
+    public SmooFetchBuilder WithBaseUrl(string baseUrl)
+    {
+        _options.BaseUrl = baseUrl;
+        return this;
+    }
+
+    /// <summary>Set the retry policy (overrides the default).</summary>
+    public SmooFetchBuilder WithRetry(RetryPolicy policy)
+    {
+        _options.RetryPolicy = policy;
+        return this;
+    }
+
+    /// <summary>Disable retries.</summary>
+    public SmooFetchBuilder WithNoRetry()
+    {
+        _options.RetryPolicy = RetryPolicy.None;
+        return this;
+    }
+
+    /// <summary>Set the per-request timeout.</summary>
+    public SmooFetchBuilder WithTimeout(TimeSpan timeout)
+    {
+        _options.Timeout = timeout;
+        return this;
+    }
+
+    /// <summary>Register an async auth-token provider.</summary>
+    public SmooFetchBuilder WithAuthTokenProvider(AuthTokenProvider provider, string scheme = "Bearer")
+    {
+        _options.AuthTokenProvider = provider;
+        _options.AuthScheme = scheme;
+        return this;
+    }
+
+    /// <summary>Add a default header that is applied to every request.</summary>
+    public SmooFetchBuilder WithDefaultHeader(string name, string value)
+    {
+        _options.DefaultHeaders[name] = value;
+        return this;
+    }
+
+    /// <summary>Override the JSON serialization options.</summary>
+    public SmooFetchBuilder WithJsonOptions(JsonSerializerOptions options)
+    {
+        _options.JsonOptions = options;
+        return this;
+    }
+
+    /// <summary>Set lifecycle hooks.</summary>
+    public SmooFetchBuilder WithHooks(LifecycleHooks hooks)
+    {
+        _options.Hooks = hooks;
+        return this;
+    }
+
+    /// <summary>Register a pre-request hook (composes with existing hooks).</summary>
+    public SmooFetchBuilder WithPreRequest(Func<HttpRequestMessage, CancellationToken, Task> hook)
+    {
+        var existing = _options.Hooks ?? new LifecycleHooks();
+        _options.Hooks = new LifecycleHooks
+        {
+            PreRequest = hook,
+            PostRequestOk = existing.PostRequestOk,
+            PostRequestErr = existing.PostRequestErr,
+        };
+        return this;
+    }
+
+    /// <summary>Register a post-request success hook (composes with existing hooks).</summary>
+    public SmooFetchBuilder WithPostRequestOk(Func<HttpResponseMessage, CancellationToken, Task> hook)
+    {
+        var existing = _options.Hooks ?? new LifecycleHooks();
+        _options.Hooks = new LifecycleHooks
+        {
+            PreRequest = existing.PreRequest,
+            PostRequestOk = hook,
+            PostRequestErr = existing.PostRequestErr,
+        };
+        return this;
+    }
+
+    /// <summary>Register a post-request error hook (composes with existing hooks).</summary>
+    public SmooFetchBuilder WithPostRequestErr(Func<Exception, CancellationToken, Task> hook)
+    {
+        var existing = _options.Hooks ?? new LifecycleHooks();
+        _options.Hooks = new LifecycleHooks
+        {
+            PreRequest = existing.PreRequest,
+            PostRequestOk = existing.PostRequestOk,
+            PostRequestErr = hook,
+        };
+        return this;
+    }
+
+    /// <summary>
+    /// Configure a circuit breaker. The retry pipeline is wrapped so consecutive
+    /// failures up to <paramref name="failureThreshold"/> trip the breaker open for
+    /// <paramref name="openDuration"/>, after which a half-open probe is allowed.
+    /// </summary>
+    public SmooFetchBuilder WithCircuitBreaker(int failureThreshold, TimeSpan openDuration, int halfOpenSamplingDuration = 1)
+    {
+        if (failureThreshold < 1)
+        {
+            throw new ArgumentOutOfRangeException(nameof(failureThreshold), "failureThreshold must be >= 1");
+        }
+
+        _options.CircuitBreaker = new CircuitBreakerOptions(failureThreshold, openDuration, halfOpenSamplingDuration);
+        return this;
+    }
+
+    /// <summary>Disable the circuit breaker (if previously configured).</summary>
+    public SmooFetchBuilder WithNoCircuitBreaker()
+    {
+        _options.CircuitBreaker = null;
+        return this;
+    }
+
+    /// <summary>
+    /// Toggle <see cref="RetryPolicy.FastFirst"/> on the currently-configured retry
+    /// policy. When the retry policy has no retries configured this re-enables retries
+    /// using <see cref="RetryPolicy.Default"/>.
+    /// </summary>
+    public SmooFetchBuilder WithFastFirst(bool fastFirst = true)
+    {
+        var current = _options.RetryPolicy.MaxRetries > 0 ? _options.RetryPolicy : RetryPolicy.Default;
+        _options.RetryPolicy = current with { FastFirst = fastFirst };
+        return this;
+    }
+
+    /// <summary>
+    /// Register an <see cref="OnRejectionCallback"/> on the currently-configured
+    /// retry policy.
+    /// </summary>
+    public SmooFetchBuilder WithOnRejection(OnRejectionCallback callback)
+    {
+        ArgumentNullException.ThrowIfNull(callback);
+        var current = _options.RetryPolicy.MaxRetries > 0 ? _options.RetryPolicy : RetryPolicy.Default;
+        _options.RetryPolicy = current with { OnRejection = callback };
+        return this;
+    }
+
+    /// <summary>Build the configured <see cref="SmooFetch"/>.</summary>
+    public SmooFetch Build()
+    {
+        return SmooFetch.Create(o =>
+        {
+            o.BaseUrl = _options.BaseUrl;
+            o.RetryPolicy = _options.RetryPolicy;
+            o.Timeout = _options.Timeout;
+            o.AuthTokenProvider = _options.AuthTokenProvider;
+            o.AuthScheme = _options.AuthScheme;
+            o.JsonOptions = _options.JsonOptions;
+            o.Hooks = _options.Hooks;
+            o.CircuitBreaker = _options.CircuitBreaker;
+            foreach (var kvp in _options.DefaultHeaders)
+            {
+                o.DefaultHeaders[kvp.Key] = kvp.Value;
+            }
+        });
+    }
+}

--- a/dotnet/SmooAI.Fetch/SmooFetchOptions.cs
+++ b/dotnet/SmooAI.Fetch/SmooFetchOptions.cs
@@ -42,4 +42,10 @@ public sealed class SmooFetchOptions
     /// Defaults to false so library consumers can still use <see cref="SmooFetch.Create(Action{SmooFetchOptions})"/>.
     /// </summary>
     public bool RequireHttpClientFactory { get; set; }
+
+    /// <summary>Optional lifecycle hooks invoked before/after each request.</summary>
+    public LifecycleHooks? Hooks { get; set; }
+
+    /// <summary>Optional circuit breaker configuration. When set, a Polly circuit breaker is composed around the retry pipeline.</summary>
+    public CircuitBreakerOptions? CircuitBreaker { get; set; }
 }

--- a/rust/fetch/tests/auth_provider_tests.rs
+++ b/rust/fetch/tests/auth_provider_tests.rs
@@ -11,6 +11,7 @@ use smooai_fetch::builder::FetchBuilder;
 use smooai_fetch::types::{AuthTokenProvider, Method, RequestInit};
 
 #[derive(Deserialize, Clone, Debug)]
+#[allow(dead_code)]
 struct TestReply {
     ok: bool,
 }


### PR DESCRIPTION
## Summary

Closes the biggest parity gap in the .NET port:

- **`SmooFetchBuilder`** fluent API (`SmooFetchBuilder.Create().With...().Build()`).
- **Polly-based circuit breaker** composed inside the resilience pipeline (`WithCircuitBreaker(failureThreshold, openDuration)`).
- **Lifecycle hooks** — `PreRequest`, `PostRequestOk`, `PostRequestErr`.
- **`OnRejection` callback** with `OnRejectionDecision` discriminated union (`Retry` / `RetryWithDelay(delay)` / `Abort` / `Skip` / `Default`) honored by the Polly `DelayGenerator`.
- **`FastFirst`** on `RetryPolicy` — first retry fires with zero delay.

Existing `SmooFetchOptions` + `SmooFetch.Create` factory remain backwards-compatible — everything new is additive. `RetryPolicy` is now a `record` so builder methods can use `with` to layer overrides.

Also includes a one-line `#[allow(dead_code)]` on `TestReply` in the Rust `auth_provider_tests.rs` added in #72 — the struct is a serde-only target so cargo errors under `-D warnings` without the annotation.

## Out of scope (follow-up)

Sliding-window rate limiter for .NET. The ticket explicitly called out that this could ship as a follow-up "if context is tight"; FastFirst is included here, leaving rate limiter as the only remaining gap.

## Test plan

- [x] `dotnet build` — clean (3 frameworks)
- [x] `dotnet test` — 27 passed (7 new builder cases)