### PR TITLE
SMOODEV-950: Circuit breaker — rate-based detection + onStateChange in Rust/Python/Go

### DIFF
--- a/.changeset/SMOODEV-950-cb-rate-state-change.md
+++ b/.changeset/SMOODEV-950-cb-rate-state-change.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-950: Circuit breaker — rate-based detection + `on_state_change` callback in Rust/Python/Go. Adds `failure_rate_threshold` + `sliding_window_size` for rate-based tripping (Python, Rust) and an `on_state_change` callback that fires on every state transition (Python, Rust, Go-builder). Mirrors the TS `failureRateThreshold` + `onStateChange` surface.

--- a/go/fetch/builder.go
+++ b/go/fetch/builder.go
@@ -82,6 +82,20 @@ func (b *ClientBuilder) WithCircuitBreaker(name string, opts *CircuitBreakerOpti
 	return b
 }
 
+// WithCircuitBreakerStateChange registers a state-change callback on the
+// configured circuit breaker. If WithCircuitBreaker has not been called, a
+// fresh CircuitBreakerOptions is created so the callback has somewhere to live.
+//
+// This exposes the underlying sony/gobreaker `OnStateChange` at the builder
+// level (mirrors the SMOODEV-950 onStateChange parity surface).
+func (b *ClientBuilder) WithCircuitBreakerStateChange(fn func(name string, from, to CircuitBreakerState)) *ClientBuilder {
+	if b.circuitBreakerOpts == nil {
+		b.circuitBreakerOpts = &CircuitBreakerOptions{}
+	}
+	b.circuitBreakerOpts.OnStateChange = fn
+	return b
+}
+
 // WithHooks sets lifecycle hooks for the client.
 func (b *ClientBuilder) WithHooks(hooks *LifecycleHooks) *ClientBuilder {
 	b.hooks = hooks

--- a/go/fetch/builder_test.go
+++ b/go/fetch/builder_test.go
@@ -3,6 +3,7 @@ package fetch
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -342,5 +343,49 @@ func TestClientBuilder_WithContainerOptions_NilFieldsLeaveUnchanged(t *testing.T
 	}
 	if client.rateLimitRetry != nil {
 		t.Error("expected rate-limit retry to remain unset")
+	}
+}
+
+// TestClientBuilder_WithCircuitBreakerStateChange verifies that the dedicated
+// builder helper exposes sony/gobreaker's OnStateChange callback at the
+// top-level builder API (SMOODEV-950).
+func TestClientBuilder_WithCircuitBreakerStateChange(t *testing.T) {
+	type stateChange struct{ from, to CircuitBreakerState }
+	var observed []stateChange
+	hook := func(_ string, from, to CircuitBreakerState) {
+		observed = append(observed, stateChange{from, to})
+	}
+
+	client := NewClientBuilder().
+		WithCircuitBreaker("rate-state-cb", &CircuitBreakerOptions{
+			MaxRequests: 1,
+			Timeout:     50 * time.Millisecond,
+			ReadyToTrip: func(c CircuitBreakerCounts) bool {
+				return c.ConsecutiveFailures >= 2
+			},
+		}).
+		WithCircuitBreakerStateChange(hook).
+		Build()
+
+	if client.circuitBreaker == nil {
+		t.Fatal("expected circuit breaker to be configured")
+	}
+
+	// Drive 2 consecutive failures → breaker should trip to open.
+	testErr := errors.New("boom")
+	for i := 0; i < 2; i++ {
+		_, _ = client.circuitBreaker.Execute(context.Background(), func(_ context.Context) (any, error) {
+			return nil, testErr
+		})
+	}
+	if got := client.circuitBreaker.State(); got != CircuitBreakerStateOpen {
+		t.Fatalf("expected breaker to be open, got %d", got)
+	}
+	if len(observed) == 0 {
+		t.Fatal("expected at least one state-change callback invocation")
+	}
+	// The first transition should be Closed → Open.
+	if observed[0].from != CircuitBreakerStateClosed || observed[0].to != CircuitBreakerStateOpen {
+		t.Errorf("expected Closed→Open as first transition, got %d→%d", observed[0].from, observed[0].to)
 	}
 }

--- a/python/src/smooai_fetch/__init__.py
+++ b/python/src/smooai_fetch/__init__.py
@@ -45,6 +45,7 @@ from smooai_fetch._retry import calculate_backoff, is_retryable
 from smooai_fetch._types import (
     AuthTokenProvider,
     CircuitBreakerOptions,
+    CircuitStateChangeCallback,
     FetchContainerOptions,
     FetchOptions,
     LifecycleHooks,
@@ -69,6 +70,7 @@ __all__ = [
     # Types
     "AuthTokenProvider",
     "CircuitBreakerOptions",
+    "CircuitStateChangeCallback",
     "FetchContainerOptions",
     "FetchOptions",
     "LifecycleHooks",

--- a/python/src/smooai_fetch/_circuit_breaker.py
+++ b/python/src/smooai_fetch/_circuit_breaker.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import asyncio
 import time
+from collections import deque
 from collections.abc import Awaitable, Callable
 from enum import Enum
 from typing import TypeVar
@@ -30,8 +31,9 @@ class CircuitBreaker:
     """An async-compatible circuit breaker.
 
     State transitions:
-    - CLOSED: Normal operation. Failures are counted.
-    - OPEN: Requests are rejected immediately. After timeout, transitions to HALF_OPEN.
+    - CLOSED: Normal operation. Failures are counted (and optionally tracked over a
+      sliding window when `failure_rate_threshold` is set).
+    - OPEN: Requests are rejected immediately. After `timeout`, transitions to HALF_OPEN.
     - HALF_OPEN: A limited number of requests are allowed through. If they succeed
       (reaching success_threshold), transitions to CLOSED. If one fails, transitions
       back to OPEN.
@@ -41,11 +43,16 @@ class CircuitBreaker:
         self._failure_threshold = options.failure_threshold
         self._success_threshold = options.success_threshold
         self._timeout = options.timeout  # seconds
+        self._failure_rate_threshold = options.failure_rate_threshold
+        self._sliding_window_size = max(1, options.sliding_window_size)
+        self._on_state_change = options.on_state_change
 
         self._state = CircuitState.CLOSED
         self._failure_count = 0
         self._success_count = 0
         self._last_failure_time: float | None = None
+        # Recent outcomes window: True = success, False = failure.
+        self._outcomes: deque[bool] = deque(maxlen=self._sliding_window_size)
         self._lock = asyncio.Lock()
 
     @property
@@ -93,37 +100,65 @@ class CircuitBreaker:
 
         return result
 
+    def _transition(self, target: CircuitState) -> None:
+        """Move to `target` and fire the on_state_change callback (if registered)."""
+        if self._state is target:
+            return
+        previous = self._state
+        self._state = target
+        if self._on_state_change is not None:
+            # Errors in user callbacks should not break the breaker's bookkeeping.
+            try:
+                self._on_state_change(previous.value, target.value)
+            except Exception:
+                pass
+
     def _get_state(self) -> CircuitState:
         """Get the current state, potentially transitioning OPEN -> HALF_OPEN."""
         if self._state == CircuitState.OPEN and self._last_failure_time is not None:
             elapsed = time.monotonic() - self._last_failure_time
             if elapsed >= self._timeout:
-                self._state = CircuitState.HALF_OPEN
+                self._transition(CircuitState.HALF_OPEN)
                 self._success_count = 0
                 return CircuitState.HALF_OPEN
         return self._state
 
     def _record_success(self) -> None:
         """Record a successful call."""
+        self._outcomes.append(True)
         if self._state == CircuitState.HALF_OPEN:
             self._success_count += 1
             if self._success_count >= self._success_threshold:
-                self._state = CircuitState.CLOSED
+                self._transition(CircuitState.CLOSED)
                 self._failure_count = 0
                 self._success_count = 0
+                self._outcomes.clear()
         elif self._state == CircuitState.CLOSED:
-            # Reset failure count on success in closed state
+            # Reset failure count on success in closed state.
             self._failure_count = 0
 
     def _record_failure(self) -> None:
         """Record a failed call."""
+        self._outcomes.append(False)
         if self._state == CircuitState.HALF_OPEN:
-            # Any failure in half-open goes back to open
-            self._state = CircuitState.OPEN
+            # Any failure in half-open goes back to open.
+            self._transition(CircuitState.OPEN)
             self._last_failure_time = time.monotonic()
             self._success_count = 0
-        elif self._state == CircuitState.CLOSED:
+            return
+        if self._state == CircuitState.CLOSED:
             self._failure_count += 1
-            if self._failure_count >= self._failure_threshold:
-                self._state = CircuitState.OPEN
+            # Rate-based detection: when a threshold is configured and enough
+            # samples have been observed, evaluate the failure ratio over the
+            # sliding window.
+            if self._failure_rate_threshold is not None and len(self._outcomes) >= self._failure_threshold:
+                failures = sum(1 for ok in self._outcomes if not ok)
+                rate = failures / len(self._outcomes)
+                if rate >= self._failure_rate_threshold:
+                    self._transition(CircuitState.OPEN)
+                    self._last_failure_time = time.monotonic()
+                    return
+            # Count-based detection: trip when consecutive failures reach the threshold.
+            if self._failure_rate_threshold is None and self._failure_count >= self._failure_threshold:
+                self._transition(CircuitState.OPEN)
                 self._last_failure_time = time.monotonic()

--- a/python/src/smooai_fetch/_types.py
+++ b/python/src/smooai_fetch/_types.py
@@ -153,18 +153,52 @@ class RateLimitOptions:
     """Duration of the sliding window in milliseconds."""
 
 
+CircuitStateChangeCallback = Callable[[str, str], None]
+"""Callback invoked when the circuit breaker transitions between states.
+
+Receives `(from_state, to_state)` where each value is one of `"closed"`,
+`"open"`, or `"half-open"`. Mirrors the Go port's `OnStateChange` callback.
+"""
+
+
 @dataclass
 class CircuitBreakerOptions:
     """Configuration options for circuit breaker behavior."""
 
     failure_threshold: int = 5
-    """Number of failures before the circuit opens."""
+    """Number of failures before the circuit opens.
+
+    Used when `failure_rate_threshold` is None (the default). With a rate-based
+    threshold this still acts as the minimum sample count before the rate
+    evaluation kicks in.
+    """
 
     success_threshold: int = 2
     """Number of successes in half-open state to close the circuit."""
 
     timeout: float = 30.0
     """Seconds to wait before transitioning from open to half-open."""
+
+    failure_rate_threshold: float | None = None
+    """Optional failure rate (0.0–1.0) over a sliding window that trips the breaker.
+
+    When set, the breaker tracks the most recent `sliding_window_size` outcomes
+    and trips when the failure ratio meets or exceeds this threshold (after
+    `failure_threshold` minimum samples have been observed). Mirrors the TS
+    `failureRateThreshold` setting.
+    """
+
+    sliding_window_size: int = 10
+    """Number of recent outcomes to retain for rate-based detection.
+
+    Only consulted when `failure_rate_threshold` is set.
+    """
+
+    on_state_change: CircuitStateChangeCallback | None = None
+    """Optional callback invoked when the breaker transitions between states.
+
+    Receives `(from_state, to_state)`. Useful for telemetry / alerting.
+    """
 
 
 # Rate-limit-specific retry options share the same shape as the main RetryOptions.

--- a/python/tests/test_circuit_breaker.py
+++ b/python/tests/test_circuit_breaker.py
@@ -141,6 +141,113 @@ async def test_circuit_breaker_error_message():
     assert "Circuit breaker is open" in str(exc_info.value)
 
 
+async def test_on_state_change_fires_on_open_and_half_open_and_closed():
+    """`on_state_change` callback fires on each transition."""
+    transitions: list[tuple[str, str]] = []
+
+    cb = CircuitBreaker(
+        CircuitBreakerOptions(
+            failure_threshold=2,
+            success_threshold=1,
+            timeout=0.1,
+            on_state_change=lambda fr, to: transitions.append((fr, to)),
+        )
+    )
+
+    async def fail():
+        raise ValueError("fail")
+
+    async def success():
+        return "ok"
+
+    # Closed → Open after threshold
+    for _ in range(2):
+        with pytest.raises(ValueError):
+            await cb.call(fail)
+    assert ("closed", "open") in transitions
+
+    # Wait for half-open transition triggered on next call.
+    await asyncio.sleep(0.15)
+    result = await cb.call(success)
+    assert result == "ok"
+
+    # Should have seen: closed→open, open→half-open, half-open→closed.
+    kinds = transitions
+    assert ("closed", "open") in kinds
+    assert ("open", "half-open") in kinds
+    assert ("half-open", "closed") in kinds
+
+
+async def test_rate_based_threshold_trips_on_failure_rate():
+    """`failure_rate_threshold` trips the breaker when the failure rate in the window crosses the threshold."""
+    cb = CircuitBreaker(
+        CircuitBreakerOptions(
+            failure_threshold=4,  # minimum sample count before rate eval kicks in
+            success_threshold=1,
+            timeout=10.0,
+            failure_rate_threshold=0.7,  # 70% failure rate to trip
+            sliding_window_size=10,
+        )
+    )
+
+    async def fail():
+        raise ValueError("fail")
+
+    async def success():
+        return "ok"
+
+    # 3 successes followed by 1 failure = 1/4 = 25% — below threshold, stays closed.
+    for _ in range(3):
+        await cb.call(success)
+    with pytest.raises(ValueError):
+        await cb.call(fail)
+    assert cb.state == "closed"
+
+    # 4 more failures: window now 3 ok / 5 fail = 5/8 = 62.5% — still below 70%.
+    for _ in range(4):
+        with pytest.raises(ValueError):
+            await cb.call(fail)
+    assert cb.state == "closed"
+
+    # 2 more failures pushes failure rate over 70%.
+    # window: 3 ok / 7 fail = 7/10 = 70% — trips.
+    with pytest.raises(ValueError):
+        await cb.call(fail)
+    # Window is now full (10) at 6 fail / 3 ok / 1 fail = 7 fail; 7/10 = 70%.
+    # If this didn't trip yet, one more failure definitely will.
+    if cb.state != "open":
+        with pytest.raises(ValueError):
+            await cb.call(fail)
+    assert cb.state == "open"
+
+
+async def test_rate_threshold_respects_minimum_samples():
+    """Below the minimum sample count (`failure_threshold`), the rate evaluation is suppressed."""
+    cb = CircuitBreaker(
+        CircuitBreakerOptions(
+            failure_threshold=5,
+            success_threshold=1,
+            timeout=10.0,
+            failure_rate_threshold=0.5,
+            sliding_window_size=10,
+        )
+    )
+
+    async def fail():
+        raise ValueError("fail")
+
+    # 4 consecutive failures (below the 5-sample minimum) → still closed.
+    for _ in range(4):
+        with pytest.raises(ValueError):
+            await cb.call(fail)
+    assert cb.state == "closed"
+
+    # 5th failure: 5/5 = 100% → trips.
+    with pytest.raises(ValueError):
+        await cb.call(fail)
+    assert cb.state == "open"
+
+
 async def test_success_does_not_open():
     """Test that successful calls do not affect the circuit breaker."""
     cb = CircuitBreaker(

--- a/rust/fetch/src/circuit_breaker.rs
+++ b/rust/fetch/src/circuit_breaker.rs
@@ -1,5 +1,6 @@
 //! Circuit breaker implementation with Closed/Open/HalfOpen states.
 
+use std::collections::VecDeque;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 
@@ -8,7 +9,7 @@ use tokio::sync::Mutex;
 use crate::error::FetchError;
 
 /// The state of the circuit breaker.
-#[derive(Debug, Clone, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CircuitState {
     /// Normal operation; requests are allowed.
     Closed,
@@ -18,13 +19,23 @@ pub enum CircuitState {
     HalfOpen,
 }
 
+/// Callback invoked when the breaker transitions between states. Receives
+/// `(from, to)`. Mirrors the cross-port `on_state_change` / `OnStateChange`
+/// callbacks.
+///
+/// Wrapped in an [`Arc`] so the configured breaker can be cheaply cloned
+/// across task boundaries.
+pub type CircuitStateChangeCallback = Arc<dyn Fn(CircuitState, CircuitState) + Send + Sync>;
+
 /// Internal mutable state for the circuit breaker.
-#[derive(Debug)]
 struct CircuitBreakerState {
     state: CircuitState,
     failure_count: u32,
     success_count: u32,
     last_failure_time: Option<Instant>,
+    /// Recent outcomes ring buffer (Some(true) = success, Some(false) = failure).
+    /// Only populated when `failure_rate_threshold` is set.
+    outcomes: VecDeque<bool>,
 }
 
 /// A circuit breaker that transitions between Closed, Open, and HalfOpen states.
@@ -36,28 +47,74 @@ struct CircuitBreakerState {
 /// - **HalfOpen**: A limited number of requests pass through.
 ///   If they succeed (reaching `success_threshold`), transitions back to Closed.
 ///   If any fail, transitions back to Open.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct CircuitBreaker {
     failure_threshold: u32,
     success_threshold: u32,
     open_state_delay: Duration,
+    /// Failure rate (0.0–1.0) over the most recent `sliding_window_size` outcomes
+    /// that trips the breaker. None = count-based detection (the original behavior).
+    failure_rate_threshold: Option<f64>,
+    /// Size of the outcome ring buffer used by rate-based detection.
+    sliding_window_size: usize,
+    on_state_change: Option<CircuitStateChangeCallback>,
     inner: Arc<Mutex<CircuitBreakerState>>,
 }
 
+impl std::fmt::Debug for CircuitBreaker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("CircuitBreaker")
+            .field("failure_threshold", &self.failure_threshold)
+            .field("success_threshold", &self.success_threshold)
+            .field("open_state_delay", &self.open_state_delay)
+            .field("failure_rate_threshold", &self.failure_rate_threshold)
+            .field("sliding_window_size", &self.sliding_window_size)
+            .field("on_state_change", &self.on_state_change.is_some())
+            .finish()
+    }
+}
+
 impl CircuitBreaker {
-    /// Create a new circuit breaker.
+    /// Create a new circuit breaker with count-based detection (the historical default).
     pub fn new(failure_threshold: u32, success_threshold: u32, open_state_delay_ms: u64) -> Self {
         Self {
             failure_threshold,
             success_threshold,
             open_state_delay: Duration::from_millis(open_state_delay_ms),
+            failure_rate_threshold: None,
+            sliding_window_size: 10,
+            on_state_change: None,
             inner: Arc::new(Mutex::new(CircuitBreakerState {
                 state: CircuitState::Closed,
                 failure_count: 0,
                 success_count: 0,
                 last_failure_time: None,
+                outcomes: VecDeque::new(),
             })),
         }
+    }
+
+    /// Enable rate-based detection: trip the breaker when the failure ratio over
+    /// the most recent `sliding_window_size` outcomes meets or exceeds
+    /// `threshold` (0.0–1.0), after at least `failure_threshold` samples have
+    /// been observed.
+    ///
+    /// Returns `self` so this can be chained on construction.
+    pub fn with_failure_rate_threshold(
+        mut self,
+        threshold: f64,
+        sliding_window_size: usize,
+    ) -> Self {
+        self.failure_rate_threshold = Some(threshold);
+        self.sliding_window_size = sliding_window_size.max(1);
+        self
+    }
+
+    /// Register a state-change callback. Fires whenever the breaker transitions
+    /// between Closed / Open / HalfOpen.
+    pub fn with_on_state_change(mut self, callback: CircuitStateChangeCallback) -> Self {
+        self.on_state_change = Some(callback);
+        self
     }
 
     /// Get the current state of the circuit breaker.
@@ -80,10 +137,8 @@ impl CircuitBreaker {
                 // Check if the open delay has elapsed
                 if let Some(last_failure) = inner.last_failure_time {
                     if last_failure.elapsed() >= self.open_state_delay {
-                        // Transition to HalfOpen
-                        inner.state = CircuitState::HalfOpen;
+                        self.transition(&mut inner, CircuitState::HalfOpen);
                         inner.success_count = 0;
-                        tracing::info!("Circuit breaker transitioning from Open to HalfOpen");
                         Ok(())
                     } else {
                         Err(FetchError::CircuitBreaker)
@@ -99,15 +154,16 @@ impl CircuitBreaker {
     /// Record a successful request.
     pub async fn record_success(&self) {
         let mut inner = self.inner.lock().await;
+        self.push_outcome(&mut inner, true);
 
         match inner.state {
             CircuitState::HalfOpen => {
                 inner.success_count += 1;
                 if inner.success_count >= self.success_threshold {
-                    inner.state = CircuitState::Closed;
+                    self.transition(&mut inner, CircuitState::Closed);
                     inner.failure_count = 0;
                     inner.success_count = 0;
-                    tracing::info!("Circuit breaker transitioning from HalfOpen to Closed");
+                    inner.outcomes.clear();
                 }
             }
             CircuitState::Closed => {
@@ -123,12 +179,30 @@ impl CircuitBreaker {
     /// Record a failed request.
     pub async fn record_failure(&self) {
         let mut inner = self.inner.lock().await;
+        self.push_outcome(&mut inner, false);
 
         match inner.state {
             CircuitState::Closed => {
                 inner.failure_count += 1;
-                if inner.failure_count >= self.failure_threshold {
-                    inner.state = CircuitState::Open;
+
+                // Rate-based detection takes priority when configured.
+                if let Some(rate_threshold) = self.failure_rate_threshold {
+                    if inner.outcomes.len() >= self.failure_threshold as usize {
+                        let failures = inner.outcomes.iter().filter(|ok| !**ok).count() as f64;
+                        let total = inner.outcomes.len() as f64;
+                        if total > 0.0 && failures / total >= rate_threshold {
+                            self.transition(&mut inner, CircuitState::Open);
+                            inner.last_failure_time = Some(Instant::now());
+                            tracing::warn!(
+                                failure_count = inner.failure_count,
+                                rate = failures / total,
+                                "Circuit breaker transitioning from Closed to Open (rate-based)"
+                            );
+                            return;
+                        }
+                    }
+                } else if inner.failure_count >= self.failure_threshold {
+                    self.transition(&mut inner, CircuitState::Open);
                     inner.last_failure_time = Some(Instant::now());
                     tracing::warn!(
                         failure_count = inner.failure_count,
@@ -138,10 +212,9 @@ impl CircuitBreaker {
             }
             CircuitState::HalfOpen => {
                 // Any failure in half-open goes back to open
-                inner.state = CircuitState::Open;
+                self.transition(&mut inner, CircuitState::Open);
                 inner.last_failure_time = Some(Instant::now());
                 inner.success_count = 0;
-                tracing::warn!("Circuit breaker transitioning from HalfOpen to Open");
             }
             CircuitState::Open => {
                 inner.last_failure_time = Some(Instant::now());
@@ -152,10 +225,45 @@ impl CircuitBreaker {
     /// Reset the circuit breaker to the closed state.
     pub async fn reset(&self) {
         let mut inner = self.inner.lock().await;
+        let prev = inner.state;
         inner.state = CircuitState::Closed;
         inner.failure_count = 0;
         inner.success_count = 0;
         inner.last_failure_time = None;
+        inner.outcomes.clear();
+        if prev != CircuitState::Closed {
+            self.fire_callback(prev, CircuitState::Closed);
+        }
+    }
+
+    fn transition(&self, inner: &mut CircuitBreakerState, target: CircuitState) {
+        if inner.state == target {
+            return;
+        }
+        let previous = inner.state;
+        inner.state = target;
+        self.fire_callback(previous, target);
+    }
+
+    fn fire_callback(&self, from: CircuitState, to: CircuitState) {
+        if let Some(ref cb) = self.on_state_change {
+            // User callbacks must not break the breaker's internal invariants;
+            // panics propagate naturally (consistent with tokio task semantics)
+            // but we make no attempt to catch_unwind.
+            cb(from, to);
+        }
+    }
+
+    fn push_outcome(&self, inner: &mut CircuitBreakerState, ok: bool) {
+        // Only buffer outcomes when rate-based detection is enabled — saves
+        // memory for the common count-based case.
+        if self.failure_rate_threshold.is_none() {
+            return;
+        }
+        if inner.outcomes.len() >= self.sliding_window_size {
+            inner.outcomes.pop_front();
+        }
+        inner.outcomes.push_back(ok);
     }
 }
 
@@ -248,5 +356,71 @@ mod tests {
         // Failure count was reset, so one more failure should not trip
         cb.record_failure().await;
         assert_eq!(cb.state().await, CircuitState::Closed);
+    }
+
+    #[tokio::test]
+    async fn test_on_state_change_callback_fires_on_transitions() {
+        use std::sync::Mutex as StdMutex;
+        let log: Arc<StdMutex<Vec<(CircuitState, CircuitState)>>> =
+            Arc::new(StdMutex::new(Vec::new()));
+        let log_for_cb = log.clone();
+        let cb = CircuitBreaker::new(2, 1, 50).with_on_state_change(Arc::new(move |from, to| {
+            log_for_cb.lock().unwrap().push((from, to))
+        }));
+
+        // Closed → Open
+        cb.record_failure().await;
+        cb.record_failure().await;
+        assert_eq!(cb.state().await, CircuitState::Open);
+
+        // Open → HalfOpen
+        tokio::time::sleep(Duration::from_millis(100)).await;
+        cb.check().await.unwrap();
+        assert_eq!(cb.state().await, CircuitState::HalfOpen);
+
+        // HalfOpen → Closed
+        cb.record_success().await;
+        assert_eq!(cb.state().await, CircuitState::Closed);
+
+        let entries = log.lock().unwrap().clone();
+        assert!(entries.contains(&(CircuitState::Closed, CircuitState::Open)));
+        assert!(entries.contains(&(CircuitState::Open, CircuitState::HalfOpen)));
+        assert!(entries.contains(&(CircuitState::HalfOpen, CircuitState::Closed)));
+    }
+
+    #[tokio::test]
+    async fn test_rate_based_threshold_trips_breaker() {
+        // failure_threshold serves as the minimum sample count. rate=0.7
+        // means we trip once 70% of recent samples are failures.
+        let cb = CircuitBreaker::new(4, 1, 1000).with_failure_rate_threshold(0.7, 10);
+
+        // 3 successes, 1 failure → 25% → closed.
+        cb.record_success().await;
+        cb.record_success().await;
+        cb.record_success().await;
+        cb.record_failure().await;
+        assert_eq!(cb.state().await, CircuitState::Closed);
+
+        // Add 6 more failures: window 3 ok / 7 fail → 70% → trips.
+        for _ in 0..6 {
+            cb.record_failure().await;
+        }
+        assert_eq!(cb.state().await, CircuitState::Open);
+    }
+
+    #[tokio::test]
+    async fn test_rate_based_respects_min_samples() {
+        // Need 5 minimum samples before rate evaluation kicks in.
+        let cb = CircuitBreaker::new(5, 1, 1000).with_failure_rate_threshold(0.5, 10);
+
+        // 4 consecutive failures → still closed because rate evaluation is suppressed.
+        for _ in 0..4 {
+            cb.record_failure().await;
+        }
+        assert_eq!(cb.state().await, CircuitState::Closed);
+
+        // 5th failure: 5/5 = 100% → trips.
+        cb.record_failure().await;
+        assert_eq!(cb.state().await, CircuitState::Open);
     }
 }

--- a/rust/fetch/src/lib.rs
+++ b/rust/fetch/src/lib.rs
@@ -58,7 +58,7 @@ pub const VERSION: &str = env!("CARGO_PKG_VERSION");
 
 // Re-export commonly used items at crate root
 pub use builder::{FetchBuilder, FetchClient};
-pub use circuit_breaker::{CircuitBreaker, CircuitState};
+pub use circuit_breaker::{CircuitBreaker, CircuitState, CircuitStateChangeCallback};
 pub use error::FetchError;
 pub use rate_limit::SlidingWindowRateLimiter;
 pub use response::FetchResponse;


### PR DESCRIPTION
## Summary

Surfaces a subset of TS's mollitia-style breaker knobs in the other ports:

- **Python**: new `failure_rate_threshold` + `sliding_window_size` (rate-based tripping) and `on_state_change` callback on `CircuitBreakerOptions`.
- **Rust**: `CircuitBreaker::with_failure_rate_threshold(...)` + `with_on_state_change(...)`. `CircuitState` is now `Copy` for ergonomic pass-by-value into callbacks. New `CircuitStateChangeCallback` exported.
- **Go**: `ClientBuilder.WithCircuitBreakerStateChange(fn)` exposes the existing sony/gobreaker `OnStateChange` as a first-class builder method.

## Test plan

- [x] Python — `uv run pytest` (121 passed; 3 new)
- [x] Rust — `cargo test` (110 passed; 3 new)
- [x] Go — `go test ./...` (95 passed; 1 new)