### PR TITLE
SMOODEV-950: Fix clippy errors blocking rust circuit breaker release

### DIFF
--- a/rust/fetch/src/circuit_breaker.rs
+++ b/rust/fetch/src/circuit_breaker.rs
@@ -120,7 +120,7 @@ impl CircuitBreaker {
     /// Get the current state of the circuit breaker.
     pub async fn state(&self) -> CircuitState {
         let inner = self.inner.lock().await;
-        inner.state.clone()
+        inner.state
     }
 
     /// Check if a request is allowed to proceed. If the circuit is open
@@ -198,7 +198,6 @@ impl CircuitBreaker {
                                 rate = failures / total,
                                 "Circuit breaker transitioning from Closed to Open (rate-based)"
                             );
-                            return;
                         }
                     }
                 } else if inner.failure_count >= self.failure_threshold {


### PR DESCRIPTION
Unblocks fetch release after SMOODEV-950 introduced 2 clippy errors under -D warnings:
- `.clone()` on Copy type
- trailing `return;` in if-block

110 cargo tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)