### PR TITLE
SMOODEV-2032: Rust smooai-fetch uses rustls, not native-tls (drop openssl-sys)

### DIFF
--- a/rust/fetch/Cargo.toml
+++ b/rust/fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smooai-fetch"
-version = "2.1.2"
+version = "3.3.11"
 edition = "2021"
 description = "A resilient HTTP fetch client with retries, timeouts, rate limiting, and circuit breaking."
 license = "MIT"
@@ -11,7 +11,7 @@ categories = ["web-programming::http-client"]
 readme = "README.md"
 
 [dependencies]
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 thiserror = "2"


### PR DESCRIPTION
The Rust `smooai-fetch` crate pulls reqwest with **default features (native-tls → openssl-sys)**. That breaks OpenSSL-less Docker builds of every downstream Rust service depending on it (directly or via smooai-observability) — and the rest of the org standardizes on rustls (api-prime, the observability SDK). Switch reqwest to `default-features = false, features = ["json", "rustls-tls"]`.

The smooai monorepo is currently `[patch.crates-io]`-pinned to this branch (SmooAI/smooai#1787) to unblock its broken Docker builds; once this republishes to crates.io, that patch is dropped.

Note: version set to 3.3.11 for the patch to satisfy the `^3` requirement — reconcile with the changeset/release flow as needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)