### PR TITLE
fix(release): stamp Cargo.lock in sync-versions; publish --locked

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -118,10 +118,11 @@ jobs:
 
             - name: Publish smooai-fetch to crates.io
               if: steps.changesets.outputs.published == 'true'
-              # --allow-dirty is needed because sync-versions.mjs modifies
-              # Cargo.toml (and rebuild updates Cargo.lock) between the
-              # committed state and publish. --locked would reject that mismatch.
-              run: cargo publish --allow-dirty --manifest-path rust/fetch/Cargo.toml
+              # --locked: sync-versions.mjs now stamps Cargo.lock in lockstep with
+              # Cargo.toml, so the lock matches and the publish build is reproducible.
+              # --allow-dirty: sync-versions.mjs modifies the manifests in-place at
+              # publish time (uncommitted), which --allow-dirty permits.
+              run: cargo publish --locked --allow-dirty --manifest-path rust/fetch/Cargo.toml
               env:
                   CARGO_REGISTRY_TOKEN: ${{ secrets.SMOOAI_CARGO_REGISTRY_TOKEN }}
 

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -28,6 +28,16 @@ const files = [
         replacement: `version = "${version}"`,
     },
     {
+        // Keep rust/fetch/Cargo.lock's own crate entry in lockstep with the Cargo.toml
+        // bump above — name-targeted so a same-versioned DEPENDENCY is never touched.
+        // Without this the lock pins the old version and `cargo build/publish --locked`
+        // rejects the mismatch (which is why the release used `--allow-dirty`); stamping
+        // it lets the publish run `--locked` reproducibly.
+        path: join(rootDir, 'rust', 'fetch', 'Cargo.lock'),
+        pattern: /(name = "smooai-fetch"\nversion = )"[^"]*"/,
+        replacement: `$1"${version}"`,
+    },
+    {
         path: join(rootDir, 'go', 'fetch', 'version.go'),
         pattern: /const Version = ".*"/,
         replacement: `const Version = "${version}"`,


### PR DESCRIPTION
Same class of bug we just fixed in smooth-operator (#111): the release bumps the Rust `Cargo.toml` version but not the lock, so the lock drifts. fetch papered over it with `cargo publish --allow-dirty` (no `--locked`, non-reproducible).

**Fix:** `sync-versions.mjs` now also stamps `rust/fetch/Cargo.lock` — name-targeted to the `smooai-fetch` `[[package]]` entry so a same-versioned dependency is never touched — and the release publishes with `--locked --allow-dirty` (reproducible lock; `--allow-dirty` still needed because sync edits the manifests in-place at publish time).

**Verified:** a simulated version bump stamps `Cargo.toml` + `Cargo.lock` together, `serde` and other deps stay put, and `cargo build --locked` builds. No-op on an already-synced tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)