### PR TITLE
SMOODEV-2513: Connect timeout for Python fetch SDK (parity with #88)

### DIFF
--- a/python/src/smooai_fetch/_timeout.py
+++ b/python/src/smooai_fetch/_timeout.py
@@ -17,4 +17,6 @@ def create_timeout(options: TimeoutOptions) -> httpx.Timeout:
         An httpx.Timeout configured with the specified timeout in seconds.
     """
     timeout_seconds = options.timeout_ms / 1000.0
-    return httpx.Timeout(timeout_seconds)
+    if options.connect_timeout_ms is None:
+        return httpx.Timeout(timeout_seconds)
+    return httpx.Timeout(timeout_seconds, connect=options.connect_timeout_ms / 1000.0)

--- a/python/src/smooai_fetch/_types.py
+++ b/python/src/smooai_fetch/_types.py
@@ -141,6 +141,15 @@ class TimeoutOptions:
     timeout_ms: float = 30000
     """Timeout duration in milliseconds."""
 
+    connect_timeout_ms: float | None = None
+    """Optional bounded connect-phase timeout in milliseconds.
+
+    When set, only the connect phase is capped at this value while the remaining
+    phases keep `timeout_ms`. Fails fast on black-holed connects (dead pod IPs
+    lingering in a ClusterIP's iptables) instead of stalling until the whole
+    timeout. Default None leaves behavior unchanged. Mirrors the Rust
+    `connect_timeout_ms` (SMOODEV-2513 / fetch#88)."""
+
 
 @dataclass
 class RateLimitOptions:

--- a/python/tests/test_timeout.py
+++ b/python/tests/test_timeout.py
@@ -1,5 +1,7 @@
 """Tests for timeout functionality."""
 
+import time
+
 import httpx
 import pytest
 import respx
@@ -77,3 +79,30 @@ async def test_connect_timeout():
 
     with pytest.raises(FetchTimeoutError):
         await fetch(URL, options)
+
+
+async def test_connect_timeout_fails_fast_on_black_hole():
+    """A bounded connect timeout fails fast on a black-holed connect instead of
+    stalling until the (much larger) whole-request timeout.
+
+    Mirrors the Rust `connect_timeout_fails_fast_on_black_hole` test
+    (SMOODEV-2513 / fetch#88). 10.255.255.1 is a non-routable address whose SYN
+    is dropped, so without a connect timeout the request hangs until the whole
+    timeout. With connect_timeout_ms set, it fails in ~the connect window.
+    """
+    connect_timeout_ms = 500
+    options = FetchOptions(
+        # Whole timeout is 10x the connect timeout — if the connect timeout is
+        # not honored this would take ~5s and the elapsed assertion fails.
+        timeout=TimeoutOptions(timeout_ms=5000, connect_timeout_ms=connect_timeout_ms),
+        retry=RetryOptions(attempts=0),
+    )
+
+    start = time.monotonic()
+    with pytest.raises(FetchTimeoutError):
+        await fetch("http://10.255.255.1:80/anything", options)
+    elapsed = time.monotonic() - start
+
+    assert elapsed < 3.0, (
+        f"connect timeout did not fire fast: elapsed {elapsed:.2f}s (connect was {connect_timeout_ms}ms)"
+    )


### PR DESCRIPTION
## Problem

The Rust fetch SDK gained a bounded connect-phase timeout in #88 (SMOODEV-2498 / SMOODEV-2481): api-prime's ~16s stalls were fresh SYNs to dead pod IPs still lingering in a ClusterIP's iptables. Without a connect timeout, the client waits the full whole-request timeout on a black-holed connect. The Python SDK had no equivalent.

## Solution

Add optional `connect_timeout_ms: float | None = None` to `TimeoutOptions`. httpx supports per-phase timeouts natively, so when set we construct `httpx.Timeout(whole_s, connect=connect_s)` — only the connect phase is capped while read/write/pool keep `timeout_ms`. A black-holed connect now fails fast (surfaced as the SDK's `TimeoutError`, since `httpx.ConnectTimeout` subclasses `httpx.TimeoutException`) instead of hanging until the whole timeout.

**Default-off:** when `connect_timeout_ms is None` the timeout construction is byte-identical to before (`httpx.Timeout(timeout_seconds)`) — existing callers are behavior-identical.

## Test

`test_connect_timeout_fails_fast_on_black_hole` mirrors the Rust `connect_timeout_fails_fast_on_black_hole`: a request to non-routable `http://10.255.255.1:80/` with a 500ms connect timeout and a 10x (5s) whole timeout must raise and return in well under 3s.

- `poe lint` / `poe format:check` / `poe typecheck` clean
- `poe test`: 127 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)