### PR TITLE
SMOODEV-2513: add bounded connect timeout to .NET SmooAI.Fetch

### DIFF
--- a/dotnet/SmooAI.Fetch.Tests/ConnectTimeoutTests.cs
+++ b/dotnet/SmooAI.Fetch.Tests/ConnectTimeoutTests.cs
@@ -1,0 +1,34 @@
+using System.Diagnostics;
+using SmooAI.Fetch;
+
+namespace SmooAI.Fetch.Tests;
+
+/// <summary>
+/// Mirrors the Rust <c>connect_timeout_tests.rs</c> port: a connect to a non-routable
+/// black-hole IP with a short ConnectTimeout must fail in ~that window, not stall until
+/// the whole-request Timeout.
+/// </summary>
+public class ConnectTimeoutTests
+{
+    // RFC 5737 / non-routable black hole — SYNs get dropped, so connect hangs until timeout.
+    private const string BlackHoleUrl = "http://10.255.255.1:80/";
+
+    private sealed record Reply(bool Ok);
+
+    [Fact]
+    public async Task ConnectTimeout_fails_fast_before_whole_timeout()
+    {
+        var fetch = SmooFetchBuilder.Create()
+            .WithNoRetry()
+            .WithConnectTimeout(TimeSpan.FromMilliseconds(500))
+            .WithTimeout(TimeSpan.FromSeconds(5))
+            .Build();
+
+        var sw = Stopwatch.StartNew();
+        await Assert.ThrowsAnyAsync<Exception>(() => fetch.GetAsync<Reply>(BlackHoleUrl));
+        sw.Stop();
+
+        // ~0.5s connect timeout, not the 5s whole-request timeout. Generous ceiling for CI jitter.
+        Assert.True(sw.Elapsed < TimeSpan.FromSeconds(3), $"expected fast connect-timeout failure, took {sw.Elapsed}");
+    }
+}

--- a/dotnet/SmooAI.Fetch/SmooFetch.cs
+++ b/dotnet/SmooAI.Fetch/SmooFetch.cs
@@ -100,7 +100,14 @@ public sealed class SmooFetch
                 "SmooFetchOptions.RequireHttpClientFactory is true — register via AddSmooFetch and resolve from DI instead of Create().");
         }
 
-        var handler = new HttpClientHandler();
+        // SocketsHttpHandler so we can honor SmooFetchOptions.ConnectTimeout when set.
+        // Left unset (null) → handler default (Infinite), i.e. behavior-identical to before.
+        var handler = new SocketsHttpHandler();
+        if (options.ConnectTimeout is { } connectTimeout)
+        {
+            handler.ConnectTimeout = connectTimeout;
+        }
+
         var client = new HttpClient(handler) { Timeout = System.Threading.Timeout.InfiniteTimeSpan };
         return new SmooFetch(client, ownsHttpClient: true, options, logger: null);
     }
@@ -108,6 +115,9 @@ public sealed class SmooFetch
     internal static SmooFetch CreateFromFactory(HttpClient client, SmooFetchOptions options, ILogger<SmooFetch> logger)
     {
         // HttpClientFactory-managed clients must not have their Timeout set (we enforce it per-request via CTS).
+        // Caveat: SmooFetchOptions.ConnectTimeout is NOT applied here — the factory owns the handler.
+        // Configure the connect timeout on the SocketsHttpHandler at DI registration
+        // (e.g. .ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { ConnectTimeout = ... })).
         client.Timeout = System.Threading.Timeout.InfiniteTimeSpan;
         return new SmooFetch(client, ownsHttpClient: false, options, logger);
     }

--- a/dotnet/SmooAI.Fetch/SmooFetchBuilder.cs
+++ b/dotnet/SmooAI.Fetch/SmooFetchBuilder.cs
@@ -65,6 +65,17 @@ public sealed class SmooFetchBuilder
         return this;
     }
 
+    /// <summary>
+    /// Set a bounded connect timeout (maps to <see cref="System.Net.Http.SocketsHttpHandler.ConnectTimeout"/>).
+    /// Mirrors the Rust <c>with_connect_timeout</c> port. Default-off; only affects
+    /// self-managed clients (not <see cref="IHttpClientFactory"/>-owned handlers).
+    /// </summary>
+    public SmooFetchBuilder WithConnectTimeout(TimeSpan connectTimeout)
+    {
+        _options.ConnectTimeout = connectTimeout;
+        return this;
+    }
+
     /// <summary>Register an async auth-token provider.</summary>
     public SmooFetchBuilder WithAuthTokenProvider(AuthTokenProvider provider, string scheme = "Bearer")
     {
@@ -219,6 +230,7 @@ public sealed class SmooFetchBuilder
             o.BaseUrl = _options.BaseUrl;
             o.RetryPolicy = _options.RetryPolicy;
             o.Timeout = _options.Timeout;
+            o.ConnectTimeout = _options.ConnectTimeout;
             o.AuthTokenProvider = _options.AuthTokenProvider;
             o.AuthScheme = _options.AuthScheme;
             o.JsonOptions = _options.JsonOptions;

--- a/dotnet/SmooAI.Fetch/SmooFetchOptions.cs
+++ b/dotnet/SmooAI.Fetch/SmooFetchOptions.cs
@@ -22,6 +22,16 @@ public sealed class SmooFetchOptions
     /// <summary>Per-request timeout. Defaults to 10 seconds, matching the TS implementation.</summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(10);
 
+    /// <summary>
+    /// Optional bounded timeout for establishing the TCP/TLS connection, mapped to
+    /// <see cref="System.Net.Http.SocketsHttpHandler.ConnectTimeout"/>. Mirrors the Rust
+    /// <c>with_connect_timeout</c> port. Defaults to <c>null</c> (unset) so existing
+    /// consumers are behaviorally unchanged — a black-holed connect otherwise stalls until
+    /// the whole-request <see cref="Timeout"/> before a retry can land on a live endpoint.
+    /// Ignored when <see cref="RequireHttpClientFactory"/> is true (the factory owns the handler).
+    /// </summary>
+    public TimeSpan? ConnectTimeout { get; set; }
+
     /// <summary>Optional auth token provider. When set, the returned token is added as <c>Authorization: Bearer {token}</c>.</summary>
     public AuthTokenProvider? AuthTokenProvider { get; set; }
 


### PR DESCRIPTION
## Problem

Parity with Rust PR #88 (SMOODEV-2498). api-prime's ~16s API stalls (SMOODEV-2481) traced to fresh SYNs black-holing to **dead pod IPs still lingering in a ClusterIP's iptables** during an endpoint-removal race. With no connect timeout, the client waits the full whole-request timeout before the existing retry can land on a live pod.

## Fix

Add a bounded **connect timeout** so a black-holed connect fails in ~the configured window and the existing retry lands on a live endpoint, while slow-but-alive handlers (governed by the whole-request timeout) are untouched.

- `SmooFetchBuilder.WithConnectTimeout(TimeSpan)` — mirrors `WithTimeout`.
- `SmooFetchOptions.ConnectTimeout: TimeSpan?` — **default `null`, so existing consumers are behaviorally unchanged**.
- Self-managed `Create(...)` path now builds a `SocketsHttpHandler` and sets `handler.ConnectTimeout` only when the option is set (unset → handler default = Infinite, byte-identical to before).

## IHttpClientFactory caveat

`ConnectTimeout` is only applied on the SDK-owned handler (`Create`). For `RequireHttpClientFactory` / DI-managed clients the factory owns the handler, so the connect timeout must be configured at registration, e.g. `.ConfigurePrimaryHttpMessageHandler(() => new SocketsHttpHandler { ConnectTimeout = ... })`. Documented inline in `CreateFromFactory`.

## Test

`ConnectTimeoutTests.cs`: a connect to a non-routable black-hole IP (`10.255.255.1:80`) with a 500ms `ConnectTimeout` and a 5s whole-request timeout throws in ~0.5s (asserted `< 3s`) instead of hanging to the whole timeout. Full suite green (`dotnet test`: 32 passed), `dotnet format --verify-no-changes` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)