### PR TITLE
SMOODEV-2716: Redact client_secret from url-encoded request-body logging

### DIFF
--- a/.changeset/redact-form-credentials.md
+++ b/.changeset/redact-form-credentials.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-2716: Redact credential params (`client_secret`, `client_id`, tokens, etc.) from url-encoded request bodies before they reach any log record. The request/response logging stored the raw form body as an opaque string, so an OAuth `client_credentials` token exchange leaked its `client_secret` to CloudWatch in plaintext. `getRequestBody` now scrubs sensitive `x-www-form-urlencoded` params via the exported `redactFormCredentials`. TypeScript only for now — the Python/Rust/Go/.NET implementations need the same redaction as a parity follow-up.

--- a/src/fetch.redact.test.ts
+++ b/src/fetch.redact.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { redactFormCredentials } from './fetch';
+
+// SMOODEV-2716: url-encoded request bodies are logged as opaque strings, so an
+// OAuth token-exchange body leaked `client_secret` to CloudWatch. These pin the
+// redaction that closes that gap.
+describe('redactFormCredentials', () => {
+    it('redacts client_secret / client_id in a token-exchange body, preserving base64 = padding', () => {
+        const body = 'grant_type=client_credentials&client_id=abc-123&client_secret=sk_EL%2BPixKPBBe%3D';
+        const out = redactFormCredentials(body);
+        expect(out).toContain('grant_type=client_credentials');
+        expect(out).toContain('client_secret=[REDACTED]');
+        expect(out).toContain('client_id=[REDACTED]');
+        expect(out).not.toContain('sk_EL');
+    });
+
+    it('leaves a form body with no sensitive params unchanged', () => {
+        const body = 'grant_type=client_credentials&scope=read';
+        expect(redactFormCredentials(body)).toBe(body);
+    });
+
+    it('does not corrupt a JSON string body (not form-encoded)', () => {
+        const body = '{"client_secret":"sk_x","a":1}';
+        expect(redactFormCredentials(body)).toBe(body);
+    });
+});

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -381,9 +381,52 @@ function getHeadersObject(headers: Headers | Record<string, string> | undefined)
     return headers;
 }
 
+// Credential params whose values must never reach a log record. The logger
+// redacts by object key (headers, JSON fields), but a url-encoded request body
+// is an opaque string it can't see into — so `client_secret=sk_...` in an OAuth
+// token-exchange body sails through in plaintext. SMOODEV-2716: a config-client
+// token exchange leaked its client_secret to CloudWatch this way.
+const REDACTED_FORM_PARAMS = new Set([
+    'client_secret',
+    'client_id',
+    'secret',
+    'password',
+    'access_token',
+    'refresh_token',
+    'token',
+    'code',
+    'assertion',
+    'client_assertion',
+    'api_key',
+    'apikey',
+]);
+
+// Scrub sensitive values from an x-www-form-urlencoded body before it is logged.
+// Splits on the FIRST `=` per pair so base64 values with `=` padding survive.
+export function redactFormCredentials(body: string): string {
+    const trimmed = body.trimStart();
+    // Only touch form-encoded strings; leave JSON (logger key-redacts that) alone.
+    if (!body.includes('=') || trimmed.startsWith('{') || trimmed.startsWith('[')) return body;
+    let changed = false;
+    const out = body
+        .split('&')
+        .map((pair) => {
+            const eq = pair.indexOf('=');
+            if (eq === -1) return pair;
+            const key = pair.slice(0, eq);
+            if (REDACTED_FORM_PARAMS.has(key.toLowerCase())) {
+                changed = true;
+                return `${key}=[REDACTED]`;
+            }
+            return pair;
+        })
+        .join('&');
+    return changed ? out : body;
+}
+
 function getRequestBody(body: any): string | undefined {
     if (!body) return undefined;
-    if (typeof body === 'string') return body;
+    if (typeof body === 'string') return redactFormCredentials(body);
     if (typeof body === 'object') return JSON.stringify(body);
     return String(body);
 }


### PR DESCRIPTION
## Problem

The request/response logger records the outbound request body via `getRequestBody`, which returned a url-encoded form body **verbatim** as an opaque string. The logger redacts by object key (headers, JSON fields) but can't see into a string, so an OAuth `client_credentials` token exchange logged `client_secret=sk_...` in **plaintext to CloudWatch**.

Surfaced during the AuthIssuer P0 (SMOODEV-2716): `@smooai/config`'s `TokenProvider.refresh` does `POST /token` with `grant_type=client_credentials&client_id=...&client_secret=sk_...`, and that whole body landed in logs.

## Fix

`getRequestBody` now runs string bodies through the new exported `redactFormCredentials`, which scrubs sensitive `x-www-form-urlencoded` params (`client_secret`, `client_id`, `access_token`, `refresh_token`, `token`, `password`, `secret`, `code`, `assertion`, `client_assertion`, `api_key`) to `[REDACTED]`. It:

- splits each pair on the **first** `=` so base64 values with `=` padding survive,
- leaves JSON string bodies untouched (they start with `{`/`[`; the logger key-redacts those),
- routes through the single choke point, so all 6 body log sites are covered.

## Tests

`src/fetch.redact.test.ts` — 3 tests (redacts secret/id while preserving base64 padding; leaves benign form bodies unchanged; doesn't corrupt JSON). `tsc --noEmit` clean.

## Scope / follow-up

TypeScript only. This is the language `@smooai/config` uses, so it stops the reported leak. The **Python / Rust / Go / .NET** implementations of `@smooai/fetch` have the same body-logging shape and need the same redaction — parity follow-up, intentionally not bundled into this incident fix.

Note: the leaked secret is already in CloudWatch history until log retention expires — **rotation is flagged for Brent** separately.

Jira: SMOODEV-2716

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018tRq2Rge3gGHCjJdNx6xDD