### PR TITLE
SMOODEV-2716: Redact credentials before they reach a log record

### DIFF
--- a/.changeset/redact-credentials-before-logging.md
+++ b/.changeset/redact-credentials-before-logging.md
@@ -1,0 +1,5 @@
+---
+'@smooai/fetch': patch
+---
+
+SMOODEV-2716: Redact credentials from everything the client logs. `@smooai/logger` performs no redaction of its own, so the `Authorization` header, the raw query string, the full URL in the log message and the request body were all reaching CloudWatch in plaintext on every request. A new internal `redact` module scrubs headers, query strings, URLs (including userinfo passwords) and bodies (url-encoded, JSON string and object forms) before they are handed to the logger; the request sent on the wire is unchanged. The Rust client gets the same treatment for the URL on its `Sending HTTP request` tracing event. Both suites load the shared cases in `spec/redaction-corpus.json`. Python, Go and .NET log nothing about a request and so are unaffected.

--- a/README.md
+++ b/README.md
@@ -345,6 +345,14 @@ const user = await api('/users/123'); // Correlation ID sent as header
 // In Service B, the correlation ID is automatically extracted and logs are linked.
 ```
 
+### Credentials are redacted before they reach a log record
+
+Everything this client logs about a request — headers, query string, URL and body — is scrubbed of credential-bearing keys first, so an OAuth token exchange or a `Bearer` header does not land in CloudWatch in plaintext. Redaction is always on and applies only to the logged copy; the request on the wire is untouched.
+
+A key is redacted when its normalized form (lowercased, `-`/`_`/`.` stripped) contains `secret`, `password`, `passwd`, `token`, `apikey`, `authorization`, `credential`, `privatekey`, `assertion`, `cookie`, `session` or `signature`, or equals `auth`, `code`, `pwd` or `sig`. The cases are pinned in [`spec/redaction-corpus.json`](spec/redaction-corpus.json), which both the TypeScript and Rust test suites load. `client_id` is deliberately **not** redacted — it is public in OAuth and load-bearing when debugging.
+
+The Rust client redacts the URL it logs (userinfo password + query params); the Python, Go and .NET clients log nothing about a request, so they have nothing to redact.
+
 ### Debug production issues faster
 
 When something goes wrong, you have the complete story — initial request, each retry attempt, circuit-breaker state changes, and the final error with a full stack trace:

--- a/rust/fetch/src/client.rs
+++ b/rust/fetch/src/client.rs
@@ -284,9 +284,11 @@ pub async fn fetch<T: DeserializeOwned + Clone + Send + 'static>(
         (url.to_string(), init)
     };
 
+    // SMOODEV-2716: a URL carries credentials in its userinfo password and its
+    // query params, and the tracing subscriber does no redaction of its own.
     tracing::debug!(
         method = %init.method,
-        url = %url,
+        url = %crate::redact::redact_url(&url),
         "Sending HTTP request"
     );
 

--- a/rust/fetch/src/lib.rs
+++ b/rust/fetch/src/lib.rs
@@ -49,6 +49,7 @@ pub mod defaults;
 pub mod error;
 pub mod hooks;
 pub mod rate_limit;
+mod redact;
 pub mod response;
 pub mod retry;
 pub mod timeout;

--- a/rust/fetch/src/redact.rs
+++ b/rust/fetch/src/redact.rs
@@ -1,0 +1,206 @@
+//! Credential redaction for anything this client hands to a logger.
+//!
+//! SMOODEV-2716. The Rust client's only logging sink for request data is the
+//! `url` field on the `Sending HTTP request` tracing event, so that is what is
+//! scrubbed here — a URL carries credentials in two places, the userinfo
+//! password and the query string. Bodies and headers are never logged by this
+//! crate, so there is deliberately nothing here for them; if a sink is ever
+//! added, extend this module and load the matching group from
+//! `spec/redaction-corpus.json` in the same change.
+//!
+//! This is log-only. The request actually sent on the wire is never touched.
+
+pub(crate) const REDACTED: &str = "[REDACTED]";
+
+/// A key is sensitive when its normalized form contains one of these.
+/// Mirrors `sensitiveKeys.contains` in `spec/redaction-corpus.json`.
+const SENSITIVE_PARTS: &[&str] = &[
+    "secret",
+    "password",
+    "passwd",
+    "token",
+    "apikey",
+    "authorization",
+    "credential",
+    "privatekey",
+    "assertion",
+    "cookie",
+    "session",
+    "signature",
+];
+
+/// ...or equals one of these. Mirrors `sensitiveKeys.equals`. Too short or too
+/// common to substring-match without shredding unrelated fields.
+const SENSITIVE_EXACT: &[&str] = &["auth", "code", "pwd", "sig"];
+
+/// `X-Api-Key`, `x_api_key` and `apiKey` are the same key as far as a leak is
+/// concerned, so separators and case are removed before matching.
+fn normalize_key(key: &str) -> String {
+    key.chars()
+        .filter(|c| !matches!(c, '-' | '_' | '.'))
+        .flat_map(char::to_lowercase)
+        .collect()
+}
+
+pub(crate) fn is_sensitive_key(key: &str) -> bool {
+    let k = normalize_key(key);
+    SENSITIVE_EXACT.contains(&k.as_str()) || SENSITIVE_PARTS.iter().any(|part| k.contains(part))
+}
+
+/// Redact sensitive params from `a=1&b=2`. Splits each pair on the FIRST `=` so
+/// a base64 value keeps its `=` padding.
+fn redact_pairs(pairs: &str) -> String {
+    pairs
+        .split('&')
+        .map(|pair| match pair.split_once('=') {
+            Some((key, _)) if is_sensitive_key(key) => format!("{key}={REDACTED}"),
+            _ => pair.to_string(),
+        })
+        .collect::<Vec<_>>()
+        .join("&")
+}
+
+/// Redact sensitive params from a query string (leading `?` optional).
+pub(crate) fn redact_query_string(search: &str) -> String {
+    match search.strip_prefix('?') {
+        Some(rest) => format!("?{}", redact_pairs(rest)),
+        None if search.is_empty() => String::new(),
+        None => redact_pairs(search),
+    }
+}
+
+/// Redact credentials from a URL string: the userinfo password and the query
+/// params. Purely textual, so relative and non-parseable URLs work unchanged
+/// and nothing is normalized behind the caller's back.
+pub(crate) fn redact_url(url: &str) -> String {
+    let (base, fragment) = match url.find('#') {
+        Some(i) => (&url[..i], &url[i..]),
+        None => (url, ""),
+    };
+
+    let with_query = match base.find('?') {
+        Some(i) => format!("{}{}", &base[..i], redact_query_string(&base[i..])),
+        None => base.to_string(),
+    };
+
+    format!("{}{fragment}", redact_userinfo_password(&with_query))
+}
+
+/// `scheme://user:password@host` -> `scheme://user:[REDACTED]@host`.
+fn redact_userinfo_password(url: &str) -> String {
+    // Authority runs from after `://` to the first `/`, `?` or `#`.
+    let Some(scheme_end) = url.find("://") else {
+        return url.to_string();
+    };
+    let authority_start = scheme_end + 3;
+    let authority_end = url[authority_start..]
+        .find(['/', '?', '#'])
+        .map_or(url.len(), |i| authority_start + i);
+    let authority = &url[authority_start..authority_end];
+
+    let Some(at) = authority.rfind('@') else {
+        return url.to_string();
+    };
+    let Some((user, _)) = authority[..at].split_once(':') else {
+        return url.to_string();
+    };
+
+    format!(
+        "{}{user}:{REDACTED}@{}",
+        &url[..authority_start],
+        &url[authority_start + at + 1..]
+    )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // Shared with the TypeScript suite. `include_str!` binds it at compile time,
+    // so the corpus cannot silently go stale relative to this test.
+    const CORPUS: &str = include_str!("../../../spec/redaction-corpus.json");
+
+    fn corpus() -> serde_json::Value {
+        serde_json::from_str(CORPUS).expect("redaction corpus must parse")
+    }
+
+    fn cases<'a>(corpus: &'a serde_json::Value, group: &str) -> &'a Vec<serde_json::Value> {
+        corpus["cases"][group]
+            .as_array()
+            .unwrap_or_else(|| panic!("corpus group `{group}` missing"))
+    }
+
+    // Positive control: a corpus that failed to load would otherwise read as
+    // "all tests passed".
+    #[test]
+    fn corpus_loads() {
+        let c = corpus();
+        assert_eq!(c["redactedWith"], REDACTED);
+        for group in ["url", "query"] {
+            assert!(!cases(&c, group).is_empty(), "group `{group}` is empty");
+        }
+    }
+
+    #[test]
+    fn url_cases() {
+        let c = corpus();
+        for case in cases(&c, "url") {
+            let input = case["input"].as_str().unwrap();
+            let expected = case["expected"].as_str().unwrap();
+            assert_eq!(
+                redact_url(input),
+                expected,
+                "url case `{}`",
+                case["name"].as_str().unwrap_or("?")
+            );
+        }
+    }
+
+    #[test]
+    fn query_cases() {
+        let c = corpus();
+        for case in cases(&c, "query") {
+            let input = case["input"].as_str().unwrap();
+            let expected = case["expected"].as_str().unwrap();
+            assert_eq!(
+                redact_query_string(input),
+                expected,
+                "query case `{}`",
+                case["name"].as_str().unwrap_or("?")
+            );
+        }
+    }
+
+    // The key list is the security contract; both languages match on the same
+    // roots, so it lives in the corpus rather than in either implementation.
+    #[test]
+    fn sensitive_key_roots_match_the_corpus() {
+        let c = corpus();
+        for part in c["sensitiveKeys"]["contains"].as_array().unwrap() {
+            let part = part.as_str().unwrap();
+            assert!(
+                is_sensitive_key(&format!("x_{part}_value")),
+                "expected a key containing `{part}` to be sensitive"
+            );
+        }
+        for key in c["sensitiveKeys"]["equals"].as_array().unwrap() {
+            let key = key.as_str().unwrap();
+            assert!(is_sensitive_key(key), "expected `{key}` to be sensitive");
+        }
+    }
+
+    #[test]
+    fn safe_identifiers_are_not_redacted() {
+        for safe in [
+            "country_code",
+            "zipcode",
+            "user_id",
+            "client_id",
+            "grant_type",
+            "scope",
+            "state",
+        ] {
+            assert!(!is_sensitive_key(safe), "`{safe}` should not be redacted");
+        }
+    }
+}

--- a/spec/redaction-corpus.json
+++ b/spec/redaction-corpus.json
@@ -1,0 +1,131 @@
+{
+    "$comment": "Shared credential-redaction corpus. Every language that has a logging sink for request data loads THIS file — do not hand-copy these cases into a language's test file. Today that is TypeScript (all six groups) and Rust (`url` and `query` only; Rust's single sink is the `url` field on the `Sending HTTP request` tracing event). Python, Go and .NET have no logging sink at all, so they implement nothing and load nothing; if a sink is ever added there, wire it to this corpus in the same PR.",
+    "redactedWith": "[REDACTED]",
+    "sensitiveKeys": {
+        "$comment": "A key is sensitive if its NORMALIZED form (lowercased, with '-', '_' and '.' stripped) contains one of `contains`, or equals one of `equals`. `equals` holds the roots that are too short or too common to substring-match without shredding unrelated fields.",
+        "contains": [
+            "secret",
+            "password",
+            "passwd",
+            "token",
+            "apikey",
+            "authorization",
+            "credential",
+            "privatekey",
+            "assertion",
+            "cookie",
+            "session",
+            "signature"
+        ],
+        "equals": ["auth", "code", "pwd", "sig"]
+    },
+    "cases": {
+        "headers": [
+            {
+                "name": "bearer authorization header",
+                "input": { "Authorization": "Bearer eyJhbGciOi.J9.sig", "Content-Type": "application/json" },
+                "expected": { "Authorization": "[REDACTED]", "Content-Type": "application/json" }
+            },
+            {
+                "name": "api key and cookie headers, any casing or separator",
+                "input": { "X-Api-Key": "sk_live_1", "x_api_key": "sk_live_2", "Cookie": "sid=abc", "set-cookie": "sid=abc; HttpOnly" },
+                "expected": { "X-Api-Key": "[REDACTED]", "x_api_key": "[REDACTED]", "Cookie": "[REDACTED]", "set-cookie": "[REDACTED]" }
+            },
+            {
+                "name": "vendor-prefixed session token header",
+                "input": { "x-amz-security-token": "IQoJb3", "X-Session-Id": "s-1" },
+                "expected": { "x-amz-security-token": "[REDACTED]", "X-Session-Id": "[REDACTED]" }
+            },
+            {
+                "name": "routine headers are left alone",
+                "input": { "Accept": "application/json", "User-Agent": "smooai-fetch", "X-Request-Id": "r-1" },
+                "expected": { "Accept": "application/json", "User-Agent": "smooai-fetch", "X-Request-Id": "r-1" }
+            }
+        ],
+        "query": [
+            { "name": "empty query", "input": "", "expected": "" },
+            { "name": "no sensitive params", "input": "?page=2&sort=asc", "expected": "?page=2&sort=asc" },
+            { "name": "api key in query", "input": "?api_key=sk_live_x&page=2", "expected": "?api_key=[REDACTED]&page=2" },
+            {
+                "name": "oauth code and token, base64 padding in value",
+                "input": "?code=abc%3D%3D&access_token=ya29.a0%2Bx&state=s1",
+                "expected": "?code=[REDACTED]&access_token=[REDACTED]&state=s1"
+            },
+            { "name": "valueless param is untouched", "input": "?debug&api_key=x", "expected": "?debug&api_key=[REDACTED]" }
+        ],
+        "url": [
+            { "name": "no query", "input": "https://api.example.com/v1/things", "expected": "https://api.example.com/v1/things" },
+            {
+                "name": "secret in query",
+                "input": "https://api.example.com/v1/things?api_key=sk_live_x&page=2",
+                "expected": "https://api.example.com/v1/things?api_key=[REDACTED]&page=2"
+            },
+            {
+                "name": "password in userinfo",
+                "input": "https://alice:hunter2@api.example.com/v1/things",
+                "expected": "https://alice:[REDACTED]@api.example.com/v1/things"
+            },
+            {
+                "name": "fragment is preserved and not scanned as query",
+                "input": "https://api.example.com/p?token=t#section=1",
+                "expected": "https://api.example.com/p?token=[REDACTED]#section=1"
+            },
+            {
+                "name": "relative url with a secret",
+                "input": "/v1/things?client_secret=shh",
+                "expected": "/v1/things?client_secret=[REDACTED]"
+            },
+            {
+                "name": "userinfo without a password is untouched",
+                "input": "https://alice@api.example.com/v1",
+                "expected": "https://alice@api.example.com/v1"
+            }
+        ],
+        "form": [
+            {
+                "name": "oauth client_credentials token exchange",
+                "input": "grant_type=client_credentials&client_id=abc-123&client_secret=sk_EL%2BPixKPBBe%3D",
+                "expected": "grant_type=client_credentials&client_id=abc-123&client_secret=[REDACTED]"
+            },
+            {
+                "name": "client_id is deliberately NOT redacted — it is public in OAuth and load-bearing for debugging",
+                "input": "client_id=abc-123&scope=read",
+                "expected": "client_id=abc-123&scope=read"
+            },
+            {
+                "name": "refresh token grant",
+                "input": "grant_type=refresh_token&refresh_token=1%2F%2F0g&client_assertion=jwt",
+                "expected": "grant_type=refresh_token&refresh_token=[REDACTED]&client_assertion=[REDACTED]"
+            },
+            { "name": "no sensitive params", "input": "a=1&b=2", "expected": "a=1&b=2" },
+            {
+                "name": "value containing = survives (split on the FIRST = only)",
+                "input": "state=a%3Db&password=p%3D%3D",
+                "expected": "state=a%3Db&password=[REDACTED]"
+            },
+            {
+                "name": "prose is not a form body — whitespace means leave it alone rather than mangle it",
+                "input": "upstream said: token=abc & then it failed",
+                "expected": "upstream said: token=abc & then it failed"
+            }
+        ],
+        "json": [
+            {
+                "name": "secret at the top level",
+                "input": "{\"client_secret\":\"sk_x\",\"a\":1}",
+                "expected": "{\"client_secret\":\"[REDACTED]\",\"a\":1}"
+            },
+            {
+                "name": "secret nested in an object and an array",
+                "input": "{\"outer\":{\"password\":\"p\"},\"list\":[{\"apiKey\":\"k\"},{\"ok\":true}]}",
+                "expected": "{\"outer\":{\"password\":\"[REDACTED]\"},\"list\":[{\"apiKey\":\"[REDACTED]\"},{\"ok\":true}]}"
+            },
+            { "name": "nothing sensitive", "input": "{\"a\":1,\"b\":[2,3]}", "expected": "{\"a\":1,\"b\":[2,3]}" },
+            {
+                "name": "a sensitive VALUE under a safe key is not detectable and is left as-is",
+                "input": "{\"note\":\"my password is hunter2\"}",
+                "expected": "{\"note\":\"my password is hunter2\"}"
+            }
+        ]
+    }
+}

--- a/src/fetch.ts
+++ b/src/fetch.ts
@@ -5,6 +5,7 @@ import { BreakerError, BreakerState, Circuit, Module, Ratelimit, RatelimitError,
 import { CONTEXT, ContextHeader, ContextKey, ContextKeyHttp, ContextKeyHttpRequest, ContextKeyHttpResponse } from '@smooai/logger/Logger';
 import { handleSchemaValidation, HumanReadableSchemaError } from '@smooai/utils/validation/standardSchema';
 import { contextLogger } from './logger';
+import { redactBody, redactHeaders, redactQueryString, redactUrl } from './redact';
 
 export { RatelimitError, TimeoutError } from 'mollitia';
 export * from 'mollitia';
@@ -369,6 +370,9 @@ function mergeHeadersWithContext(headersInit?: HeadersInit): HeadersInit {
     return newHeadersInit;
 }
 
+// Both helpers below feed logger payloads only — never the outgoing request —
+// so they redact credentials in place. `@smooai/logger` does no redaction of its
+// own, so if it isn't scrubbed here it reaches CloudWatch in plaintext.
 function getHeadersObject(headers: Headers | Record<string, string> | undefined): Record<string, string> {
     if (!headers) return {};
     if (headers instanceof Headers) {
@@ -376,16 +380,13 @@ function getHeadersObject(headers: Headers | Record<string, string> | undefined)
         headers.forEach((value, key) => {
             result[key] = value;
         });
-        return result;
+        return redactHeaders(result);
     }
-    return headers;
+    return redactHeaders(headers);
 }
 
 function getRequestBody(body: any): string | undefined {
-    if (!body) return undefined;
-    if (typeof body === 'string') return body;
-    if (typeof body === 'object') return JSON.stringify(body);
-    return String(body);
+    return redactBody(body);
 }
 
 function prepareDefaultInit(init?: RequestInit): RequestInit {
@@ -641,14 +642,15 @@ async function doFetch<Schema extends StandardSchemaV1 = never>(
     }
 
     const urlObj = new URL(url.toString());
+    const safeUrl = redactUrl(url.toString());
 
-    logger.debug(`Sending HTTP request "${modifiedInit.method} ${url}"`, {
+    logger.debug(`Sending HTTP request "${modifiedInit.method} ${safeUrl}"`, {
         [ContextKey.Http]: {
             [ContextKeyHttp.Request]: {
                 [ContextKeyHttpRequest.Method]: modifiedInit.method,
                 [ContextKeyHttpRequest.Host]: urlObj.host,
                 [ContextKeyHttpRequest.Path]: urlObj.pathname,
-                [ContextKeyHttpRequest.QueryString]: urlObj.search,
+                [ContextKeyHttpRequest.QueryString]: redactQueryString(urlObj.search),
                 [ContextKeyHttpRequest.Headers]: getHeadersObject(modifiedInit.headers as Headers),
                 [ContextKeyHttpRequest.Body]: getRequestBody(modifiedInit.body),
             },
@@ -683,13 +685,13 @@ async function doFetch<Schema extends StandardSchemaV1 = never>(
         }
 
         if (error instanceof TimeoutError) {
-            logger.error(error, `HTTP request "${modifiedInit.method} ${url}" timed out (${error.name}) after ${options.timeout!.timeoutMs} ms`, {
+            logger.error(error, `HTTP request "${modifiedInit.method} ${safeUrl}" timed out (${error.name}) after ${options.timeout!.timeoutMs} ms`, {
                 [ContextKey.Http]: {
                     [ContextKeyHttp.Request]: {
                         [ContextKeyHttpRequest.Method]: modifiedInit.method,
                         [ContextKeyHttpRequest.Host]: urlObj.host,
                         [ContextKeyHttpRequest.Path]: urlObj.pathname,
-                        [ContextKeyHttpRequest.QueryString]: urlObj.search,
+                        [ContextKeyHttpRequest.QueryString]: redactQueryString(urlObj.search),
                         [ContextKeyHttpRequest.Headers]: getHeadersObject(modifiedInit.headers as Headers),
                         [ContextKeyHttpRequest.Body]: getRequestBody(modifiedInit.body),
                     },
@@ -697,20 +699,20 @@ async function doFetch<Schema extends StandardSchemaV1 = never>(
             });
         } else if (options.retry && error instanceof HTTPResponseError) {
             if (options.retry.onRejection && options.retry.onRejection(error, 1)) {
-                logger.error(error, `HTTP request "${modifiedInit.method} ${url}" retries failed after ${options.retry.attempts} retries`, {
+                logger.error(error, `HTTP request "${modifiedInit.method} ${safeUrl}" retries failed after ${options.retry.attempts} retries`, {
                     [ContextKey.Http]: {
                         [ContextKeyHttp.Request]: {
                             [ContextKeyHttpRequest.Method]: modifiedInit.method,
                             [ContextKeyHttpRequest.Host]: urlObj.host,
                             [ContextKeyHttpRequest.Path]: urlObj.pathname,
-                            [ContextKeyHttpRequest.QueryString]: urlObj.search,
+                            [ContextKeyHttpRequest.QueryString]: redactQueryString(urlObj.search),
                             [ContextKeyHttpRequest.Headers]: getHeadersObject(modifiedInit.headers as Headers),
                             [ContextKeyHttpRequest.Body]: getRequestBody(modifiedInit.body),
                         },
                         [ContextKeyHttp.Response]: {
                             [ContextKeyHttpResponse.StatusCode]: error.response.status,
                             [ContextKeyHttpResponse.Headers]: getHeadersObject(error.response.headers),
-                            [ContextKeyHttpResponse.Body]: error.response.dataString,
+                            [ContextKeyHttpResponse.Body]: redactBody(error.response.dataString),
                         },
                     },
                 });
@@ -788,6 +790,7 @@ function generateFetchWithOptions(options: { init?: RequestInit; requestOptions?
         const __requestOptions = prepareDefaultOptions(merge({}, _requestOptions, requestOptions));
         const logger = __requestOptions.logger || contextLoggerToUse;
         const urlObj = new URL(url.toString());
+        const safeUrl = redactUrl(url.toString());
         const headers = getHeadersObject(__init.headers as Headers);
         const requestBody = getRequestBody(__init.body);
 
@@ -797,7 +800,7 @@ function generateFetchWithOptions(options: { init?: RequestInit; requestOptions?
             if (error instanceof RatelimitError) {
                 logger.error(
                     error,
-                    `HTTP request "${__init.method} ${url}" rate limited (${error.name}) - more than ${
+                    `HTTP request "${__init.method} ${safeUrl}" rate limited (${error.name}) - more than ${
                         options.containerOptions!.rateLimit?.limitForPeriod
                     } in ${options.containerOptions!.rateLimit?.limitPeriodMs} ms - ${error.remainingTimeInRatelimit} ms left in rate limit`,
                     {
@@ -806,7 +809,7 @@ function generateFetchWithOptions(options: { init?: RequestInit; requestOptions?
                                 [ContextKeyHttpRequest.Method]: __init.method,
                                 [ContextKeyHttpRequest.Host]: urlObj.host,
                                 [ContextKeyHttpRequest.Path]: urlObj.pathname,
-                                [ContextKeyHttpRequest.QueryString]: urlObj.search,
+                                [ContextKeyHttpRequest.QueryString]: redactQueryString(urlObj.search),
                                 [ContextKeyHttpRequest.Headers]: headers,
                                 [ContextKeyHttpRequest.Body]: requestBody,
                             },
@@ -814,13 +817,13 @@ function generateFetchWithOptions(options: { init?: RequestInit; requestOptions?
                     },
                 );
             } else if (error instanceof BreakerError) {
-                logger.error(error, `HTTP request "${__init.method} ${url}" circuit open (${error.name})`, {
+                logger.error(error, `HTTP request "${__init.method} ${safeUrl}" circuit open (${error.name})`, {
                     [ContextKey.Http]: {
                         [ContextKeyHttp.Request]: {
                             [ContextKeyHttpRequest.Method]: __init.method,
                             [ContextKeyHttpRequest.Host]: urlObj.host,
                             [ContextKeyHttpRequest.Path]: urlObj.pathname,
-                            [ContextKeyHttpRequest.QueryString]: urlObj.search,
+                            [ContextKeyHttpRequest.QueryString]: redactQueryString(urlObj.search),
                             [ContextKeyHttpRequest.Headers]: headers,
                             [ContextKeyHttpRequest.Body]: requestBody,
                         },

--- a/src/redact.spec.ts
+++ b/src/redact.spec.ts
@@ -1,0 +1,91 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+import { isSensitiveKey, redactBody, redactHeaders, redactQueryString, redactUrl } from './redact';
+
+// SMOODEV-2716. The cases live in spec/redaction-corpus.json, shared with the
+// Rust suite — do not inline them here, or the two implementations drift.
+const corpusPath = join(dirname(fileURLToPath(import.meta.url)), '..', 'spec', 'redaction-corpus.json');
+
+interface Case<TInput, TExpected> {
+    name: string;
+    input: TInput;
+    expected: TExpected;
+}
+
+const corpus = JSON.parse(readFileSync(corpusPath, 'utf8')) as {
+    redactedWith: string;
+    sensitiveKeys: { contains: string[]; equals: string[] };
+    cases: {
+        headers: Case<Record<string, string>, Record<string, string>>[];
+        query: Case<string, string>[];
+        url: Case<string, string>[];
+        form: Case<string, string>[];
+        json: Case<string, string>[];
+    };
+};
+
+describe('redaction corpus', () => {
+    // Positive control: a corpus that failed to load reads as "all tests passed".
+    it('loaded every group', () => {
+        for (const [group, cases] of Object.entries(corpus.cases)) {
+            expect(cases.length, `group ${group} is empty`).toBeGreaterThan(0);
+        }
+        expect(corpus.redactedWith).toBe('[REDACTED]');
+    });
+
+    it.each(corpus.cases.headers)('headers: $name', ({ input, expected }) => {
+        expect(redactHeaders(input)).toEqual(expected);
+    });
+
+    it.each(corpus.cases.query)('query: $name', ({ input, expected }) => {
+        expect(redactQueryString(input)).toBe(expected);
+    });
+
+    it.each(corpus.cases.url)('url: $name', ({ input, expected }) => {
+        expect(redactUrl(input)).toBe(expected);
+    });
+
+    it.each(corpus.cases.form)('form: $name', ({ input, expected }) => {
+        expect(redactBody(input)).toBe(expected);
+    });
+
+    it.each(corpus.cases.json)('json: $name', ({ input, expected }) => {
+        expect(redactBody(input)).toBe(expected);
+    });
+
+    // The key list is the security contract; keeping it in the corpus means the
+    // Rust side matches on the same roots.
+    it.each(corpus.sensitiveKeys.contains)('treats a key containing %s as sensitive', (part) => {
+        expect(isSensitiveKey(`x_${part}_value`)).toBe(true);
+    });
+
+    it.each(corpus.sensitiveKeys.equals)('treats the exact key %s as sensitive', (key) => {
+        expect(isSensitiveKey(key)).toBe(true);
+    });
+});
+
+describe('redactBody', () => {
+    it('redacts an object body without stringifying secrets first', () => {
+        expect(redactBody({ client_secret: 'sk_x', a: 1 })).toBe('{"client_secret":"[REDACTED]","a":1}');
+    });
+
+    it('returns undefined for an absent body', () => {
+        expect(redactBody(undefined)).toBeUndefined();
+        expect(redactBody(null)).toBeUndefined();
+        expect(redactBody('')).toBeUndefined();
+    });
+
+    it('leaves an unparseable JSON-ish string alone rather than mangling it', () => {
+        expect(redactBody('{not json')).toBe('{not json');
+    });
+});
+
+describe('isSensitiveKey', () => {
+    it('does not redact identifiers that merely resemble credential names', () => {
+        for (const safe of ['country_code', 'zipcode', 'user_id', 'client_id', 'grant_type', 'scope', 'state']) {
+            expect(isSensitiveKey(safe), safe).toBe(false);
+        }
+    });
+});

--- a/src/redact.ts
+++ b/src/redact.ts
@@ -1,0 +1,124 @@
+/**
+ * Credential redaction for anything this client hands to a logger.
+ *
+ * SMOODEV-2716: an OAuth `client_credentials` token exchange leaked its
+ * `client_secret` to CloudWatch in plaintext. The original diagnosis blamed the
+ * url-encoded request body alone, but `@smooai/logger` performs no redaction of
+ * any kind — so the `Authorization` header, the raw query string and the full
+ * URL in the log message were leaking too, on every request, at debug level.
+ *
+ * Everything here is log-only. The request actually sent on the wire is never
+ * touched.
+ */
+
+export const REDACTED = '[REDACTED]';
+
+// A key is sensitive when its normalized form CONTAINS one of these.
+const SENSITIVE_PARTS = [
+    'secret',
+    'password',
+    'passwd',
+    'token',
+    'apikey',
+    'authorization',
+    'credential',
+    'privatekey',
+    'assertion',
+    'cookie',
+    'session',
+    'signature',
+];
+
+// ...or EQUALS one of these. Too short or too common to substring-match without
+// shredding unrelated fields (`code` would hit `country_code`, `zipcode`, ...).
+const SENSITIVE_EXACT = new Set(['auth', 'code', 'pwd', 'sig']);
+
+// `X-Api-Key`, `x_api_key` and `apiKey` are the same key as far as a leak is
+// concerned, so separators and case are removed before matching.
+function normalizeKey(key: string): string {
+    return key.toLowerCase().replace(/[-_.]/g, '');
+}
+
+export function isSensitiveKey(key: string): boolean {
+    const k = normalizeKey(key);
+    return SENSITIVE_EXACT.has(k) || SENSITIVE_PARTS.some((part) => k.includes(part));
+}
+
+/** Redact sensitive entries of a header map. Returns a copy. */
+export function redactHeaders(headers: Record<string, string>): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const [key, value] of Object.entries(headers)) {
+        out[key] = isSensitiveKey(key) ? REDACTED : value;
+    }
+    return out;
+}
+
+// Shared by the query string and the url-encoded body: both are `a=1&b=2`.
+// Splits each pair on the FIRST `=` so a base64 value keeps its `=` padding.
+function redactPairs(pairs: string): string {
+    return pairs
+        .split('&')
+        .map((pair) => {
+            const eq = pair.indexOf('=');
+            if (eq === -1) return pair;
+            const key = pair.slice(0, eq);
+            return isSensitiveKey(key) ? `${key}=${REDACTED}` : pair;
+        })
+        .join('&');
+}
+
+/** Redact sensitive params from a `?a=1&b=2` query string (leading `?` optional). */
+export function redactQueryString(search: string): string {
+    if (!search) return search;
+    return search.startsWith('?') ? `?${redactPairs(search.slice(1))}` : redactPairs(search);
+}
+
+// scheme://user:password@host — the password half of URL userinfo.
+const URL_USERINFO_PASSWORD = /^([a-z][a-z0-9+.-]*:\/\/[^/?#@]*:)[^/?#@]*@/i;
+
+/**
+ * Redact credentials from a URL string: userinfo password and query params.
+ * Purely textual, so relative URLs and non-parseable strings work unchanged and
+ * nothing gets normalized behind the caller's back.
+ */
+export function redactUrl(url: string): string {
+    const hash = url.indexOf('#');
+    const base = hash === -1 ? url : url.slice(0, hash);
+    const fragment = hash === -1 ? '' : url.slice(hash);
+
+    const q = base.indexOf('?');
+    const withQuery = q === -1 ? base : `${base.slice(0, q)}${redactQueryString(base.slice(q))}`;
+
+    return `${withQuery.replace(URL_USERINFO_PASSWORD, `$1${REDACTED}@`)}${fragment}`;
+}
+
+// JSON.stringify does the traversal (and keeps today's throw-on-cycle behavior),
+// so the replacer only has to decide one key at a time.
+function redactingReplacer(key: string, value: unknown): unknown {
+    return key && isSensitiveKey(key) ? REDACTED : value;
+}
+
+/**
+ * Redact a request/response body for logging. Handles objects, JSON strings and
+ * url-encoded strings. Anything else — HTML, prose, an upstream error page — is
+ * returned untouched rather than mangled by a form parser it isn't.
+ */
+export function redactBody(body: unknown): string | undefined {
+    if (body === undefined || body === null || body === '') return undefined;
+    if (typeof body === 'object') return JSON.stringify(body, redactingReplacer);
+    if (typeof body !== 'string') return String(body);
+
+    const trimmed = body.trimStart();
+    if (trimmed.startsWith('{') || trimmed.startsWith('[')) {
+        try {
+            return JSON.stringify(JSON.parse(body), redactingReplacer);
+        } catch {
+            return body;
+        }
+    }
+
+    // A url-encoded form body is percent-encoded, so it never contains raw
+    // whitespace. Whitespace means this is free text — leave it alone.
+    if (!body.includes('=') || /\s/.test(body)) return body;
+    return redactPairs(body);
+}


### PR DESCRIPTION
## Problem

PR #94 diagnosed a `client_secret` leak as a url-encoded-request-body problem and redacted only that, in TypeScript only. The diagnosis was too narrow.

`@smooai/logger` performs **no redaction of any kind** (grep it — there is no `redact`/`censor` path). So on every request, at debug level, this client was already handing the logger:

| what | where | leaks |
|---|---|---|
| `Authorization` / `Cookie` / `X-Api-Key` headers | `getHeadersObject(...)` | bearer tokens, API keys, session cookies |
| raw query string | `QueryString: urlObj.search` | `?api_key=…`, `?code=…` |
| full URL, inside the message string | `` `Sending HTTP request "${method} ${url}"` `` | same, plus userinfo passwords |
| request body | `getRequestBody(...)` | form **and** JSON — #94 skipped JSON on the false premise that the logger key-redacts it |
| error response body | `error.response.dataString` | whatever upstream echoed back |

## Fix

One `src/redact.ts`, applied at the two helpers every log site already routes through plus the query string and each message URL. Log-only — the request sent on the wire is never touched.

- **headers** — redacted by key
- **query strings / url-encoded bodies** — split on the *first* `=` so base64 `=` padding survives
- **URLs** — userinfo password and query params; purely textual, so relative and malformed URLs pass through without normalization
- **bodies** — objects and JSON strings via a `JSON.stringify` replacer (keeps today's throw-on-cycle behavior); free text with whitespace is left alone rather than mangled by a form parser it isn't

A key is sensitive when its normalized form (lowercased, `-`/`_`/`.` stripped) **contains** `secret`, `password`, `passwd`, `token`, `apikey`, `authorization`, `credential`, `privatekey`, `assertion`, `cookie`, `session`, `signature`, or **equals** `auth`, `code`, `pwd`, `sig`. `country_code`, `zipcode`, `grant_type`, `scope`, `state` and `client_id` are pinned as *not* sensitive.

**`client_id` is deliberately not redacted** (#94 did redact it): it is public by design in OAuth and load-bearing when debugging a token exchange.

## The other four languages — corrected finding

The brief expected the same hole live in Python, Rust, Go and .NET. It is not:

- **Rust** logs exactly one thing about a request: `url = %url` on the `Sending HTTP request` event. That is a real leak (query params, userinfo) and is fixed. Nothing else.
- **Python** and **Go** have no logging call at all.
- **.NET** stores an `ILogger<SmooFetch>` and never calls it — grep for `_logger.` returns nothing.

So no redaction helper is added to Python/Go/.NET; an unwired helper would read as a guarantee that isn't one.

## Parity enforcement (Spec C)

`spec/redaction-corpus.json` holds 25 cases across six groups plus the sensitive-key roots. TypeScript loads all six; Rust loads `url` + `query` — the groups matching a sink it actually has. The corpus is `include_str!`-bound on the Rust side so it cannot go stale, and each suite has a positive control asserting the groups it loaded are non-empty, so a corpus that failed to load reads red instead of "all passed". `cargo package --allow-dirty` verified: the `#[cfg(test)]` module is cfg-stripped before the cross-directory `include_str!` is expanded, so the crate still publishes.

## Verification

- `vitest run` — 99 passed (46 new)
- `cargo test --all-targets` — all green, `redact::tests::*` confirmed present in the output
- `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `oxfmt --check`, `tsc --noEmit` clean

Supersedes #94, which I'll close with a pointer here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC