### PR TITLE
SMOODEV-2513: Commit the version sync, and give Go a resolvable module path

### DIFF
--- a/.changeset/release-version-sync-and-go-module-path.md
+++ b/.changeset/release-version-sync-and-go-module-path.md
@@ -1,0 +1,9 @@
+---
+'@smooai/fetch': patch
+---
+
+Fix the release pipeline so shipped artifacts carry the version they claim, and give the Go module a resolvable path.
+
+`version:sync` ran _after_ `changeset publish`, mutating manifests in the CI workspace that were never committed — so every git tag shipped stale version constants (`go/fetch/v3.3.10` contained `const Version = "2.1.2"`) and `cargo publish --allow-dirty` existed only to tolerate the dirt. The sync now runs inside `changeset version`, so the bumped manifests land in the release commit; `--allow-dirty` is gone; and `node scripts/sync-versions.mjs --check` runs in CI as a guard that fails loudly on any skew, including a pattern that stopped matching.
+
+The Go module path gains the `/v3` major suffix Go requires above v1. Import `github.com/SmooAI/fetch/go/fetch/v3` (package identifier is still `fetch`); tags through `go/fetch/v3.4.0` predate the suffix and do not resolve. The suffix is derived from `package.json`'s major and is covered by the same guard, so a future major bump cannot leave it behind.

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -68,6 +68,9 @@ jobs:
               run: dotnet restore SmooAI.Fetch.sln
               working-directory: dotnet
 
+            - name: Version consistency
+              run: pnpm version:check
+
             - name: Typecheck
               run: pnpm typecheck
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,6 +77,9 @@ jobs:
               run: dotnet restore SmooAI.Fetch.sln
               working-directory: dotnet
 
+            - name: Version consistency
+              run: pnpm version:check
+
             - name: Typecheck
               run: pnpm typecheck
 
@@ -89,8 +92,12 @@ jobs:
             - name: Build
               run: pnpm build
 
-            - name: Format
-              run: pnpm format
+            # Deliberately a CHECK, not `pnpm format`. A formatter that rewrites
+            # files here leaves the tree dirty at `cargo publish` time, which is
+            # what `--allow-dirty` used to hide. Formatting the release commit
+            # itself is `version:release`'s job.
+            - name: Format check
+              run: pnpm format:check && pnpm python:format:check && pnpm rust:fmt:check && pnpm go:fmt:check && pnpm dotnet:format:check
 
             - name: Version Update 🦋
               id: changesets
@@ -98,6 +105,7 @@ jobs:
               with:
                   commit: '🦋 New version release'
                   title: '🦋 New version release'
+                  version: pnpm run version:release
                   publish: pnpm ci:publish
                   createGithubReleases: true
               env:
@@ -118,11 +126,11 @@ jobs:
 
             - name: Publish smooai-fetch to crates.io
               if: steps.changesets.outputs.published == 'true'
-              # --locked: sync-versions.mjs now stamps Cargo.lock in lockstep with
-              # Cargo.toml, so the lock matches and the publish build is reproducible.
-              # --allow-dirty: sync-versions.mjs modifies the manifests in-place at
-              # publish time (uncommitted), which --allow-dirty permits.
-              run: cargo publish --locked --allow-dirty --manifest-path rust/fetch/Cargo.toml
+              # No --allow-dirty: sync-versions.mjs now runs during `changeset
+              # version`, so the manifests are already committed and the tree is
+              # clean here. If this ever fails on dirt, something upstream is
+              # rewriting files during the release — fix that, don't re-add the flag.
+              run: cargo publish --locked --manifest-path rust/fetch/Cargo.toml
               env:
                   CARGO_REGISTRY_TOKEN: ${{ secrets.SMOOAI_CARGO_REGISTRY_TOKEN }}
 

--- a/README.md
+++ b/README.md
@@ -198,15 +198,15 @@ flowchart LR
 
 ## 📦 Install
 
-| Language   | Package                                                        | Install                                   |
-| ---------- | -------------------------------------------------------------- | ----------------------------------------- |
-| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                  |
-| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                |
-| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                  |
-| Go         | `github.com/SmooAI/fetch/go/fetch`                             | `go get github.com/SmooAI/fetch/go/fetch` |
-| .NET       | [`SmooAI.Fetch`](https://www.nuget.org/packages/SmooAI.Fetch)  | `dotnet add package SmooAI.Fetch`         |
+| Language   | Package                                                        | Install                                      |
+| ---------- | -------------------------------------------------------------- | -------------------------------------------- |
+| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                     |
+| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                   |
+| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                     |
+| Go         | `github.com/SmooAI/fetch/go/fetch/v3`                          | `go get github.com/SmooAI/fetch/go/fetch/v3` |
+| .NET       | [`SmooAI.Fetch`](https://www.nuget.org/packages/SmooAI.Fetch)  | `dotnet add package SmooAI.Fetch`            |
 
-> **Go note:** `go get` currently resolves a pseudo-version tracking `main` (the module path doesn't yet carry the `/v3` suffix the `go/fetch/v3.x` tags would need, so tagged versions don't resolve). `main` is what's released everywhere else; a proper `/v3` module path is planned.
+> **Go note:** the module path carries the `/v3` major suffix Go requires above v1, so the `go/fetch/v3.x` tags resolve. The import path is `github.com/SmooAI/fetch/go/fetch/v3`; the package identifier is still `fetch`. Tags minted before this change (through `go/fetch/v3.4.0`) point at commits whose `go.mod` lacked the suffix and will not resolve — use `v3.4.1` or later.
 
 Language-specific source lives in [`src/`](./src/) (TypeScript), [`python/`](./python/), [`rust/`](./rust/), [`go/`](./go/), and [`dotnet/`](./dotnet/).
 

--- a/dotnet/SmooAI.Fetch/README.md
+++ b/dotnet/SmooAI.Fetch/README.md
@@ -118,7 +118,7 @@ var user = await fetch.GetAsync<User>("/users/me", cancellationToken: cts.Token)
 - [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) — TypeScript / Node
 - [`smooai-fetch`](https://crates.io/crates/smooai-fetch) — Rust
 - [`smooai-fetch`](https://pypi.org/project/smooai-fetch/) — Python
-- [`github.com/SmooAI/fetch/go/fetch`](https://github.com/SmooAI/fetch/tree/main/go/fetch) — Go
+- [`github.com/SmooAI/fetch/go/fetch/v3`](https://github.com/SmooAI/fetch/tree/main/go/fetch) — Go
 
 ## License
 

--- a/dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj
+++ b/dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>SmooAI.Fetch</PackageId>
-    <Version>3.3.0</Version>
+    <Version>3.4.0</Version>
     <Authors>SmooAI</Authors>
     <Company>SmooAI</Company>
     <Description>Resilient HTTP client for .NET with Polly-based retry, timeouts, typed JSON responses, and auth token injection. Port of @smooai/fetch.</Description>

--- a/go/fetch/README.md
+++ b/go/fetch/README.md
@@ -58,15 +58,15 @@ Ever had a Go microservice pile up goroutines because a downstream API was down?
 ### Install
 
 ```bash
-go get github.com/SmooAI/fetch/go/fetch
+go get github.com/SmooAI/fetch/go/fetch/v3
 ```
 
-| Language   | Package                                                        | Install                                   |
-| ---------- | -------------------------------------------------------------- | ----------------------------------------- |
-| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                  |
-| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                |
-| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                  |
-| Go         | `github.com/SmooAI/fetch/go/fetch`                             | `go get github.com/SmooAI/fetch/go/fetch` |
+| Language   | Package                                                        | Install                                      |
+| ---------- | -------------------------------------------------------------- | -------------------------------------------- |
+| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                     |
+| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                   |
+| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                     |
+| Go         | `github.com/SmooAI/fetch/go/fetch/v3`                          | `go get github.com/SmooAI/fetch/go/fetch/v3` |
 
 ## The Power of Resilient Fetching
 
@@ -75,7 +75,7 @@ go get github.com/SmooAI/fetch/go/fetch
 Watch how smooai-fetch handles common failure scenarios:
 
 ```go
-import "github.com/SmooAI/fetch/go/fetch"
+import "github.com/SmooAI/fetch/go/fetch/v3"
 
 type ApiData struct {
     ID    string `json:"id"`
@@ -121,7 +121,7 @@ resp, err := fetch.Get[Repos](ctx, nil, "https://api.github.com/user/repos", nil
 
 ```go
 import (
-    "github.com/SmooAI/fetch/go/fetch"
+    "github.com/SmooAI/fetch/go/fetch/v3"
     "time"
 )
 
@@ -174,7 +174,7 @@ fmt.Println("Created user:", resp.Data.ID)
 ```go
 import (
     "errors"
-    "github.com/SmooAI/fetch/go/fetch"
+    "github.com/SmooAI/fetch/go/fetch/v3"
     "time"
 )
 
@@ -364,7 +364,7 @@ Out of the box, smooai-fetch is configured for the real world:
 ```go
 import (
     "errors"
-    "github.com/SmooAI/fetch/go/fetch"
+    "github.com/SmooAI/fetch/go/fetch/v3"
 )
 
 resp, err := fetch.Get[Data](ctx, client, "https://api.example.com/data", nil)

--- a/go/fetch/go.mod
+++ b/go/fetch/go.mod
@@ -1,4 +1,4 @@
-module github.com/SmooAI/fetch/go/fetch
+module github.com/SmooAI/fetch/go/fetch/v3
 
 go 1.23.0
 

--- a/go/fetch/version.go
+++ b/go/fetch/version.go
@@ -1,4 +1,4 @@
 package fetch
 
 // Version is the current version of the smooai-fetch Go package.
-const Version = "2.1.2"
+const Version = "3.4.0"

--- a/package.json
+++ b/package.json
@@ -83,8 +83,8 @@
     "scripts": {
         "aibranch": "pnpm generate-git-branch",
         "build": "pnpm tsdown && pnpm run python:build && pnpm run rust:build && pnpm run go:build && pnpm run dotnet:build",
-        "check-all": "pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test && pnpm run python:typecheck && pnpm run python:lint && pnpm run python:format:check && pnpm run rust:fmt:check && pnpm run rust:lint && pnpm run rust:test && pnpm run go:fmt:check && pnpm run go:lint && pnpm run go:test && pnpm run dotnet:format:check && pnpm run dotnet:test && pnpm run build",
-        "ci:publish": "pnpm build && pnpm changeset publish && pnpm run version:sync",
+        "check-all": "pnpm run version:check && pnpm run typecheck && pnpm run lint && pnpm run format:check && pnpm run test && pnpm run python:typecheck && pnpm run python:lint && pnpm run python:format:check && pnpm run rust:fmt:check && pnpm run rust:lint && pnpm run rust:test && pnpm run go:fmt:check && pnpm run go:lint && pnpm run go:test && pnpm run dotnet:format:check && pnpm run dotnet:test && pnpm run build",
+        "ci:publish": "pnpm build && pnpm changeset publish",
         "format": "oxfmt --write . && pnpm run python:format && pnpm run rust:fmt && pnpm run go:fmt && pnpm run dotnet:format",
         "lint": "oxlint . && pnpm run python:lint && pnpm run rust:lint && pnpm run go:lint",
         "lint:fix": "oxlint --fix .",
@@ -118,7 +118,9 @@
         "dotnet:pack": "(cd dotnet && dotnet pack SmooAI.Fetch/SmooAI.Fetch.csproj -c Release --nologo -o ./artifacts)",
         "dotnet:format": "(cd dotnet && dotnet format SmooAI.Fetch.sln)",
         "dotnet:format:check": "(cd dotnet && dotnet format SmooAI.Fetch.sln --verify-no-changes)",
-        "version:sync": "node scripts/sync-versions.mjs"
+        "version:sync": "node scripts/sync-versions.mjs",
+        "version:check": "node scripts/sync-versions.mjs --check",
+        "version:release": "changeset version && node scripts/sync-versions.mjs && oxfmt --write ."
     },
     "dependencies": {
         "@faker-js/faker": "^9.6.0",

--- a/python/README.md
+++ b/python/README.md
@@ -71,12 +71,12 @@ or with [uv](https://docs.astral.sh/uv/):
 uv add smooai-fetch
 ```
 
-| Language   | Package                                                        | Install                                   |
-| ---------- | -------------------------------------------------------------- | ----------------------------------------- |
-| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                  |
-| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                |
-| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                  |
-| Go         | `github.com/SmooAI/fetch/go/fetch`                             | `go get github.com/SmooAI/fetch/go/fetch` |
+| Language   | Package                                                        | Install                                      |
+| ---------- | -------------------------------------------------------------- | -------------------------------------------- |
+| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                     |
+| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                   |
+| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                     |
+| Go         | `github.com/SmooAI/fetch/go/fetch/v3`                          | `go get github.com/SmooAI/fetch/go/fetch/v3` |
 
 ## The Power of Resilient Fetching
 
@@ -353,7 +353,7 @@ except SchemaValidationError as e:
 
 - [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) - TypeScript/JavaScript version
 - [`smooai-fetch` (Rust)](https://crates.io/crates/smooai-fetch) - Rust version
-- `github.com/SmooAI/fetch/go/fetch` - Go version
+- `github.com/SmooAI/fetch/go/fetch/v3` - Go version
 
 ## Development
 

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smooai-fetch"
-version = "2.1.2"
+version = "3.4.0"
 description = "A resilient HTTP fetch client with retries, timeouts, rate limiting, and circuit breaking."
 # readme = "README.md"
 authors = [{ name = "SmooAI", email = "brent@smooai.com" }]

--- a/python/src/smooai_fetch/__init__.py
+++ b/python/src/smooai_fetch/__init__.py
@@ -4,7 +4,7 @@ A resilient HTTP fetch client with retries, timeouts, rate limiting,
 and circuit breaking.
 """
 
-__version__ = "2.1.2"
+__version__ = "3.4.0"
 
 # Core client
 # Builder

--- a/python/tests/test_basic.py
+++ b/python/tests/test_basic.py
@@ -1,5 +1,8 @@
 """Basic tests for smooai-fetch package imports and version."""
 
+import json
+from pathlib import Path
+
 from smooai_fetch import (
     DEFAULT_RETRY_OPTIONS,
     DEFAULT_TIMEOUT_MS,
@@ -27,8 +30,19 @@ from smooai_fetch import (
 )
 
 
-def test_version():
-    assert __version__ == "2.1.2"
+def test_version_matches_package_json():
+    """package.json is the single source of truth for the version across all five
+    ports; scripts/sync-versions.mjs stamps it into pyproject.toml.
+
+    This used to be `assert __version__ == "2.1.2"`. Asserting a literal made the
+    test agree with whatever the package happened to say, so it stayed green for
+    the entire time pyproject.toml was pinned at 2.1.2 while package.json shipped
+    3.4.0 -- the drift it was supposed to catch was the thing it locked in.
+    """
+    package_json = json.loads((Path(__file__).parents[2] / "package.json").read_text())
+    assert __version__ == package_json["version"], (
+        "pyproject.toml is out of sync with package.json -- run `node scripts/sync-versions.mjs`"
+    )
 
 
 def test_default_retry_options():

--- a/rust/fetch/Cargo.lock
+++ b/rust/fetch/Cargo.lock
@@ -1284,7 +1284,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smooai-fetch"
-version = "2.1.2"
+version = "3.4.0"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",

--- a/rust/fetch/Cargo.toml
+++ b/rust/fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smooai-fetch"
-version = "2.1.2"
+version = "3.4.0"
 edition = "2021"
 description = "A resilient HTTP fetch client with retries, timeouts, rate limiting, and circuit breaking."
 license = "MIT"

--- a/rust/fetch/README.md
+++ b/rust/fetch/README.md
@@ -72,12 +72,12 @@ or via cargo:
 cargo add smooai-fetch
 ```
 
-| Language   | Package                                                        | Install                                   |
-| ---------- | -------------------------------------------------------------- | ----------------------------------------- |
-| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                  |
-| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                |
-| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                  |
-| Go         | `github.com/SmooAI/fetch/go/fetch`                             | `go get github.com/SmooAI/fetch/go/fetch` |
+| Language   | Package                                                        | Install                                      |
+| ---------- | -------------------------------------------------------------- | -------------------------------------------- |
+| TypeScript | [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) | `pnpm add @smooai/fetch`                     |
+| Python     | [`smooai-fetch`](https://pypi.org/project/smooai-fetch/)       | `pip install smooai-fetch`                   |
+| Rust       | [`smooai-fetch`](https://crates.io/crates/smooai-fetch)        | `cargo add smooai-fetch`                     |
+| Go         | `github.com/SmooAI/fetch/go/fetch/v3`                          | `go get github.com/SmooAI/fetch/go/fetch/v3` |
 
 ## The Power of Resilient Fetching
 
@@ -370,7 +370,7 @@ match client.fetch("https://api.example.com/data", init).await {
 
 - [`@smooai/fetch`](https://www.npmjs.com/package/@smooai/fetch) - TypeScript/JavaScript version
 - [`smooai-fetch` (Python)](https://pypi.org/project/smooai-fetch/) - Python version
-- `github.com/SmooAI/fetch/go/fetch` - Go version
+- `github.com/SmooAI/fetch/go/fetch/v3` - Go version
 
 ## Development
 

--- a/rust/fetch/src/lib.rs
+++ b/rust/fetch/src/lib.rs
@@ -87,8 +87,23 @@ pub async fn fetch<T: serde::de::DeserializeOwned + Clone + Send + 'static>(
 mod tests {
     use super::*;
 
+    /// package.json is the single source of truth for the version across all
+    /// five ports; `scripts/sync-versions.mjs` stamps it into Cargo.toml.
+    ///
+    /// This used to be `assert_eq!(VERSION, "2.1.2")`. Asserting a literal made
+    /// the test agree with whatever the crate happened to say, so it stayed
+    /// green for the entire time Cargo.toml was pinned at 2.1.2 while
+    /// package.json shipped 3.4.0 — the drift it was supposed to catch was the
+    /// thing it locked in.
     #[test]
-    fn test_version() {
-        assert_eq!(VERSION, "2.1.2");
+    fn version_matches_package_json() {
+        const PACKAGE_JSON: &str = include_str!("../../../package.json");
+        let pkg: serde_json::Value =
+            serde_json::from_str(PACKAGE_JSON).expect("package.json must parse");
+        let expected = pkg["version"].as_str().expect("package.json has a version");
+        assert_eq!(
+            VERSION, expected,
+            "Cargo.toml is out of sync with package.json — run `node scripts/sync-versions.mjs`"
+        );
     }
 }

--- a/rust/fetch/tests/integration_tests.rs
+++ b/rust/fetch/tests/integration_tests.rs
@@ -438,8 +438,3 @@ async fn test_circuit_breaker_recovery() {
     assert!(response.ok);
     assert_eq!(cb.state().await, CircuitState::Closed);
 }
-
-#[tokio::test]
-async fn test_version_constant() {
-    assert_eq!(smooai_fetch::VERSION, "2.1.2");
-}

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -47,6 +47,13 @@ const files = [
         replacement: `version = "${version}"`,
     },
     {
+        // `smooai_fetch.__version__` is a plain literal, not read from package
+        // metadata — so PyPI could ship 3.4.0 while the module reported 2.1.2.
+        path: join(rootDir, 'python', 'src', 'smooai_fetch', '__init__.py'),
+        pattern: /^__version__ = ".*"$/m,
+        replacement: `__version__ = "${version}"`,
+    },
+    {
         path: join(rootDir, 'rust', 'fetch', 'Cargo.toml'),
         pattern: /^version = ".*"$/m,
         replacement: `version = "${version}"`,

--- a/scripts/sync-versions.mjs
+++ b/scripts/sync-versions.mjs
@@ -1,20 +1,44 @@
 #!/usr/bin/env node
 
 /**
- * Synchronizes version from package.json to all sub-package manifests.
+ * Synchronizes the version in package.json to every other version-bearing file
+ * in the repo, and — with `--check` — asserts they already agree.
+ *
+ * Run as part of `changeset version`, so the synced manifests are COMMITTED with
+ * the version bump. It used to run after `changeset publish` instead, which
+ * mutated the CI workspace and threw the result away: every git tag shipped the
+ * wrong version constants (`git show go/fetch/v3.3.10:go/fetch/version.go` said
+ * 2.1.2 while package.json said 3.3.10), and `cargo publish --allow-dirty`
+ * existed only to paper over the resulting dirt.
+ *
+ * `--check` is the guard that keeps that from coming back. It fails loudly —
+ * exit 1, naming each file and both versions — and it also fails when a pattern
+ * stops matching, because a guard that finds nothing to check must not report
+ * success.
  */
 
 import { readFileSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
+import { dirname, join, relative } from 'path';
 import { fileURLToPath } from 'url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const rootDir = join(__dirname, '..');
+const check = process.argv.includes('--check');
 
 const packageJson = JSON.parse(readFileSync(join(rootDir, 'package.json'), 'utf8'));
 const version = packageJson.version;
+const major = Number(version.split('.')[0]);
 
-console.log(`Syncing version ${version} to all sub-packages...`);
+if (!Number.isInteger(major)) {
+    console.error(`package.json version "${version}" has no integer major component.`);
+    process.exit(1);
+}
+
+// Go requires a `/vN` module-path suffix for major >= 2, and NO suffix below it.
+// Without it `go get github.com/SmooAI/fetch/go/fetch@v3.3.10` resolves nothing —
+// which is exactly what every `go/fetch/v3.x` tag did until this was added.
+const GO_MODULE_BASE = 'github.com/SmooAI/fetch/go/fetch';
+const goModulePath = major >= 2 ? `${GO_MODULE_BASE}/v${major}` : GO_MODULE_BASE;
 
 const files = [
     {
@@ -43,29 +67,58 @@ const files = [
         replacement: `const Version = "${version}"`,
     },
     {
+        // The module path's major suffix, not a version string — but it is derived
+        // from the same number, so it belongs in the same sync and the same guard.
+        path: join(rootDir, 'go', 'fetch', 'go.mod'),
+        pattern: /^module \S+$/m,
+        replacement: `module ${goModulePath}`,
+    },
+    {
         path: join(rootDir, 'dotnet', 'SmooAI.Fetch', 'SmooAI.Fetch.csproj'),
         pattern: /<Version>.*<\/Version>/,
         replacement: `<Version>${version}</Version>`,
     },
 ];
 
+const problems = [];
+
 for (const file of files) {
+    const rel = relative(rootDir, file.path);
+    let content;
     try {
-        const content = readFileSync(file.path, 'utf8');
-        const updated = content.replace(file.pattern, file.replacement);
-        if (content !== updated) {
-            writeFileSync(file.path, updated);
-            console.log(`  Updated ${file.path}`);
-        } else {
-            console.log(`  Already up to date: ${file.path}`);
-        }
+        content = readFileSync(file.path, 'utf8');
     } catch (error) {
-        if (error.code === 'ENOENT') {
-            console.log(`  Skipped (not found): ${file.path}`);
-        } else {
-            throw error;
-        }
+        if (error.code !== 'ENOENT') throw error;
+        problems.push(`${rel}: expected file is missing`);
+        continue;
+    }
+
+    // A pattern that no longer matches would make `replace` a no-op, which reads
+    // as "already up to date". Treat it as a failure in both modes.
+    if (!file.pattern.test(content)) {
+        problems.push(`${rel}: pattern ${file.pattern} no longer matches — the sync would silently do nothing`);
+        continue;
+    }
+
+    const updated = content.replace(file.pattern, file.replacement);
+    if (content === updated) {
+        if (!check) console.log(`  Already up to date: ${rel}`);
+        continue;
+    }
+
+    if (check) {
+        problems.push(`${rel}: out of sync with package.json version ${version} (expected \`${file.replacement}\`)`);
+    } else {
+        writeFileSync(file.path, updated);
+        console.log(`  Updated ${rel}`);
     }
 }
 
-console.log('Done!');
+if (problems.length > 0) {
+    console.error(`\nVersion consistency check FAILED against package.json ${version}:\n`);
+    for (const problem of problems) console.error(`  ✗ ${problem}`);
+    console.error(`\nRun \`node scripts/sync-versions.mjs\` and commit the result.\n`);
+    process.exit(1);
+}
+
+console.log(check ? `All manifests agree with package.json ${version}.` : 'Done!');


### PR DESCRIPTION
Two halves of the same defect: nothing enforced that the versions we ship match the version we claim.

## Spec A — the sync ran too late to matter

`ci:publish` was `pnpm build && changeset publish && pnpm run version:sync`. The sync rewrote manifests in a CI workspace *after* the publish, and nothing committed the result — so every git tag shipped stale constants:

```
$ git show go/fetch/v3.3.10:go/fetch/version.go
const Version = "2.1.2"
```

`cargo publish --allow-dirty` existed only to tolerate the dirt that same rewrite left behind.

- Sync moved into the changesets `version` lifecycle (`version: pnpm run version:release` on the action), so bumped manifests land in the release commit.
- `version:sync` dropped from `ci:publish`.
- `cargo publish --locked`, no `--allow-dirty`.
- The release's `pnpm format` step is now a format **check**. A formatter that rewrites files mid-release is the *other* way that tree goes dirty, and `--allow-dirty` was hiding both. Formatting the release commit itself is `version:release`'s job (`changeset version && sync-versions && oxfmt --write .`), which also keeps the generated `CHANGELOG.md` formatted.

## Spec B — the Go module path resolved nothing, ever

`module github.com/SmooAI/fetch/go/fetch` carries no `/vN` suffix, which Go requires above v1. So `go get github.com/SmooAI/fetch/go/fetch@v3.3.10` failed against every tag ever minted, and the README told users to expect a `main` pseudo-version.

Now `github.com/SmooAI/fetch/go/fetch/v3`, derived from `package.json`'s major so a future major bump carries it automatically. No internal Go source imported the module path (single package, one directory); the READMEs did, and are updated — including the install line and the "tagging fix in flight" note, which now states the real situation: tags through `go/fetch/v3.4.0` predate the suffix and will not resolve; `v3.4.1` onward will.

**Post-merge verification is still owed**: a real `GOFLAGS=-mod=mod go get github.com/SmooAI/fetch/go/fetch/v3@v3.4.1` against proxy.golang.org can only run once the release mints that tag. I'll run it and report.

## The guard both halves were missing

`node scripts/sync-versions.mjs --check` asserts every manifest — python, Cargo.toml, Cargo.lock, version.go, csproj, **and go.mod's major suffix** — agrees with `package.json`. Wired into `pr-checks.yml`, `release.yml` (before anything is built or published) and `check-all`.

It fails loudly, exit 1, naming each file and the expected value. It also fails when a **pattern stops matching**, because a guard whose regex silently finds nothing would otherwise report success — the same fail-open shape as the bug it is guarding.

Hand-verified red both ways:

```
$ node scripts/sync-versions.mjs --check          # before the sync
  ✗ python/pyproject.toml: out of sync with package.json version 3.4.0 …
  ✗ go/fetch/go.mod: out of sync … (expected `module github.com/SmooAI/fetch/go/fetch/v3`)
  exit=1

$ sed -i '' 's|/go/fetch/v3|/go/fetch/v2|' go/fetch/go.mod && node scripts/sync-versions.mjs --check
  ✗ go/fetch/go.mod: out of sync with package.json version 3.4.0 …
  exit=1
```

## Also in this commit: the overdue sync itself

python `2.1.2 → 3.4.0`, Cargo.toml + Cargo.lock `2.1.2 → 3.4.0`, version.go `2.1.2 → 3.4.0`, csproj `3.3.0 → 3.4.0`. Without this the new guard would be red on `main` from the moment it lands.

## Verification

- `go build ./... && go vet ./... && gofmt -l . && go test ./...` — green on the `/v3` path
- `cargo check --all-targets` — green at 3.4.0
- `oxfmt --check .` clean
- guard exercised red → sync → green, twice, as above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC