### PR TITLE
Sync the manifests to 3.4.1 — main is red on the new version guard

### DIFF
--- a/dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj
+++ b/dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj
@@ -10,7 +10,7 @@
     <NoWarn>$(NoWarn);CS1591</NoWarn>
 
     <PackageId>SmooAI.Fetch</PackageId>
-    <Version>3.4.0</Version>
+    <Version>3.4.1</Version>
     <Authors>SmooAI</Authors>
     <Company>SmooAI</Company>
     <Description>Resilient HTTP client for .NET with Polly-based retry, timeouts, typed JSON responses, and auth token injection. Port of @smooai/fetch.</Description>

--- a/go/fetch/version.go
+++ b/go/fetch/version.go
@@ -1,4 +1,4 @@
 package fetch
 
 // Version is the current version of the smooai-fetch Go package.
-const Version = "3.4.0"
+const Version = "3.4.1"

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "smooai-fetch"
-version = "3.4.0"
+version = "3.4.1"
 description = "A resilient HTTP fetch client with retries, timeouts, rate limiting, and circuit breaking."
 # readme = "README.md"
 authors = [{ name = "SmooAI", email = "brent@smooai.com" }]

--- a/python/src/smooai_fetch/__init__.py
+++ b/python/src/smooai_fetch/__init__.py
@@ -4,7 +4,7 @@ A resilient HTTP fetch client with retries, timeouts, rate limiting,
 and circuit breaking.
 """
 
-__version__ = "3.4.0"
+__version__ = "3.4.1"
 
 # Core client
 # Builder

--- a/rust/fetch/Cargo.lock
+++ b/rust/fetch/Cargo.lock
@@ -1284,7 +1284,7 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "smooai-fetch"
-version = "3.4.0"
+version = "3.4.1"
 dependencies = [
  "opentelemetry",
  "opentelemetry_sdk",

--- a/rust/fetch/Cargo.toml
+++ b/rust/fetch/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "smooai-fetch"
-version = "3.4.0"
+version = "3.4.1"
 edition = "2021"
 description = "A resilient HTTP fetch client with retries, timeouts, rate limiting, and circuit breaking."
 license = "MIT"


### PR DESCRIPTION
Merging #98 triggered a release that bumped `package.json` to **3.4.1** through the *old* pipeline, where `version:sync` ran after `changeset publish` and the result was thrown away. #99 landed the fix a few minutes later, so `main` now carries `package.json` at 3.4.1 and every other manifest at 3.4.0 — and the new `version:check` step reds every lane, including the in-flight release run.

That is the guard working on its first day, not a regression from #99: the 3.4.1 artifacts genuinely shipped 3.4.0 constants. One `node scripts/sync-versions.mjs`, committed.

```
python/pyproject.toml                   3.4.0 -> 3.4.1
python/src/smooai_fetch/__init__.py     3.4.0 -> 3.4.1
rust/fetch/Cargo.toml                   3.4.0 -> 3.4.1
rust/fetch/Cargo.lock                   3.4.0 -> 3.4.1
go/fetch/version.go                     3.4.0 -> 3.4.1
dotnet/SmooAI.Fetch/SmooAI.Fetch.csproj 3.4.0 -> 3.4.1
go/fetch/go.mod                         /v3 (unchanged, major is still 3)
```

Releases from here run `version:release`, which syncs inside `changeset version` and commits the result, so this is the last time it needs doing by hand.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0152bbE1veqfG1SVJdyLCBxC